### PR TITLE
fix: move config validation into Start() function

### DIFF
--- a/pkg/inbound_proxy.go
+++ b/pkg/inbound_proxy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 	ginprometheus "github.com/zsais/go-gin-prometheus"
+	"gopkg.in/dealancer/validate.v2"
 )
 
 const errorResponseHeader = "X-Semgrep-Private-Link-Error"
@@ -17,6 +18,11 @@ const proxyResponseHeader = "X-Semgrep-Private-Link"
 const wireguardHttpPort = 80
 
 func (config *InboundProxyConfig) Start(verbose bool) (func() error, error) {
+	// ensure config is valid
+	if err := validate.Validate(config); err != nil {
+		return nil, fmt.Errorf("invalid inbound config: %v", err)
+	}
+
 	// setup wireguard
 	dev, tnet, err := SetupWireguard(&config.Wireguard, verbose)
 	if err != nil {

--- a/pkg/outbound_proxy.go
+++ b/pkg/outbound_proxy.go
@@ -1,14 +1,21 @@
 package pkg
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/dealancer/validate.v2"
 )
 
-func (config *OutboundProxyConfig) Start() {
+func (config *OutboundProxyConfig) Start() error {
+	// ensure config is valid
+	if err := validate.Validate(config); err != nil {
+		return fmt.Errorf("invalid outbound config: %v", err)
+	}
+
 	go func() {
 		baseUrl, err := url.Parse(config.BaseUrl)
 		if err != nil {
@@ -30,4 +37,5 @@ func (config *OutboundProxyConfig) Start() {
 
 		http.ListenAndServe(config.Listen, proxy)
 	}()
+	return nil
 }


### PR DESCRIPTION
We shouldn't require users to have a valid inbound/outbound config section if it's not enabled