### PR TITLE
add commands for generating public/private keypair

### DIFF
--- a/cmd/genkey.go
+++ b/cmd/genkey.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+var genkeyCmd = &cobra.Command{
+	Use:   "genkey",
+	Short: "Generates a random private key in base64 and prints it to stdout",
+	Run: func(cmd *cobra.Command, args []string) {
+		privateKey, err := wgtypes.GeneratePrivateKey()
+		if err != nil {
+			log.Panic(fmt.Errorf("failed to generate private key: %v", err))
+		}
+
+		fmt.Println(base64.StdEncoding.EncodeToString(privateKey[:]))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(genkeyCmd)
+}

--- a/cmd/pubkey.go
+++ b/cmd/pubkey.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+var pubkeyCmd = &cobra.Command{
+	Use:   "pubkey",
+	Short: "Reads a base64 private key from stdin, outputs the corresponding base64 public key",
+	Run: func(cmd *cobra.Command, args []string) {
+		keyBase64, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			log.Panic(err)
+		}
+
+		keyBytes := make([]byte, 32)
+		n, err := base64.StdEncoding.Decode(keyBytes, keyBase64)
+		if err != nil {
+			log.Panic(err)
+		}
+		if n != 32 {
+			log.Panic("not enough bytes")
+		}
+
+		privateKey, err := wgtypes.NewKey(keyBytes)
+		if err != nil {
+			log.Panic(err)
+		}
+
+		publicKey := privateKey.PublicKey()
+
+		fmt.Println(base64.StdEncoding.EncodeToString(publicKey[:]))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pubkeyCmd)
+}


### PR DESCRIPTION
Mimics `wg genkey` and `wg pubkey`

```bash
% bin/semgrep-network-broker genkey
wH1u7cnvY3xsNc6phgDPSudSbcklpJIjOIufNOdmOGM=
% echo "wH1u7cnvY3xsNc6phgDPSudSbcklpJIjOIufNOdmOGM=" | bin/semgrep-network-broker pubkey
xaHEN6jslvgb1fRNOoi9Sde95eJ6rrPGNpQCPImPdig=
```