### PR TITLE
don't un-escape characters in the URL

### DIFF
--- a/pkg/inbound_proxy.go
+++ b/pkg/inbound_proxy.go
@@ -29,6 +29,7 @@ func (config *InboundProxyConfig) Start(tnet *netstack.Net) error {
 	// setup http server
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
+	r.UseRawPath = true // we want this proxy to be transparent, so don't un-escape characters in the URL
 	r.Use(gin.LoggerWithConfig(gin.LoggerConfig{
 		SkipPaths: config.Logging.SkipPaths,
 	}), gin.Recovery())


### PR DESCRIPTION
The GitLab API expects repos to be referenced by `orgname%2Freponame`, but the broker was un-escaping the `%2F` to `/` before relaying it on which caused problems. Fix is to have the broker operate on raw URLs