### PR TITLE
set HTTP methods the proper way for SCM shortcuts

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -259,25 +259,25 @@ func LoadConfig(configFiles []string) (*Config, error) {
 			// repo info
 			AllowlistItem{
 				URL:               gitHubBaseUrl.JoinPath("/repos/:owner/:repo").String(),
-				Methods:           HttpMethods(MethodGet),
+				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
 			// PR info
 			AllowlistItem{
 				URL:               gitHubBaseUrl.JoinPath("/repos/:owner/:repo/pulls").String(),
-				Methods:           HttpMethods(MethodGet),
+				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
 			// post PR comment
 			AllowlistItem{
 				URL:               gitHubBaseUrl.JoinPath("/repos/:owner/:repo/pulls/:number/comments").String(),
-				Methods:           HttpMethods(MethodPost),
+				Methods:           ParseHttpMethods([]string{"POST"}),
 				SetRequestHeaders: headers,
 			},
 			// post issue comment
 			AllowlistItem{
 				URL:               gitHubBaseUrl.JoinPath("/repos/:owner/:repo/issues/:number/comments").String(),
-				Methods:           HttpMethods(MethodPost),
+				Methods:           ParseHttpMethods([]string{"POST"}),
 				SetRequestHeaders: headers,
 			})
 	}
@@ -298,37 +298,37 @@ func LoadConfig(configFiles []string) (*Config, error) {
 			// repo info
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/projects/:project").String(),
-				Methods:           HttpMethods(MethodGet),
+				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
 			// MR info
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/projects/:project/merge_requests").String(),
-				Methods:           HttpMethods(MethodGet),
+				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
 			// MR versions
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/projects/:project/merge_requests/:number/versions").String(),
-				Methods:           HttpMethods(MethodGet),
+				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
 			// post MR comment
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/projects/:project/merge_requests/:number/discussions").String(),
-				Methods:           HttpMethods(MethodGet | MethodPost),
+				Methods:           ParseHttpMethods([]string{"GET", "POST"}),
 				SetRequestHeaders: headers,
 			},
 			// update MR comment
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/projects/:project/merge_requests/:number/discussions/:discussion/notes/:note").String(),
-				Methods:           HttpMethods(MethodPut),
+				Methods:           ParseHttpMethods([]string{"PUT"}),
 				SetRequestHeaders: headers,
 			},
 			// resolve MR comment
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/projects/:project/merge_requests/:number/discussions/:discussion").String(),
-				Methods:           HttpMethods(MethodPut),
+				Methods:           ParseHttpMethods([]string{"PUT"}),
 				SetRequestHeaders: headers,
 			},
 		)

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -83,7 +83,7 @@ func TestSensitiveBase64StringParse(t *testing.T) {
 	}
 }
 
-func TestBitSet(t *testing.T) {
+func TestBitSetStringParse(t *testing.T) {
 	bsGet := ParseHttpMethods([]string{"GET"})
 
 	if bsGet.Test(MethodGet) != true {
@@ -108,7 +108,7 @@ func TestBitSet(t *testing.T) {
 	}
 }
 
-func TestHttpMethodParse(t *testing.T) {
+func TestHttpMethodsDecodeHook(t *testing.T) {
 	type TestStruct struct {
 		Methods HttpMethods
 	}


### PR DESCRIPTION
`Method*` consts are bit offsets, not actual values. Better to use `ParseHttpMethods()` instead.

/cc @sinat101 