### PR TITLE
add support for matching with `HasPrefix` to `FilteredRelayConfig`

### DIFF
--- a/examples/github-pr-comment-relay.yaml
+++ b/examples/github-pr-comment-relay.yaml
@@ -1,4 +1,4 @@
-# This config is for the the semgrep-network-broker relay command
+# This config is for the semgrep-network-broker relay command
 #
 # You can test this out by:
 # 1. Running `semgrep-network-broker relay -c examples/github-pr-comment-relay.yaml`
@@ -12,5 +12,9 @@ outbound:
     github-pr-comments:
       destinationUrl: https://semgrep.dev/api/webhook
       jsonPath: "$.comment.body"
-      contains:
+      hasPrefix:
       - "/semgrep"
+      # it is also possible to support only a subset of available commands; for example, you could remove the line
+      # above and uncomment the line below to remove support for re-opening issues through PR review comments, while
+      # still allowing them to be ignored:
+      # - "/semgrep ignore"

--- a/examples/github-pr-comment-relay.yaml
+++ b/examples/github-pr-comment-relay.yaml
@@ -12,9 +12,7 @@ outbound:
     github-pr-comments:
       destinationUrl: https://semgrep.dev/api/webhook
       jsonPath: "$.comment.body"
+      # Here, we use `hasPrefix` to ensure only PR comments beginning with "/semgrep"
+      # are relayed to the webhook destination.
       hasPrefix:
       - "/semgrep"
-      # it is also possible to support only a subset of available commands; for example, you could remove the line
-      # above and uncomment the line below to remove support for re-opening issues through PR review comments, while
-      # still allowing them to be ignored:
-      # - "/semgrep ignore"

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -216,6 +216,7 @@ type FilteredRelayConfig struct {
 	JSONPath       string   `mapstructure:"jsonPath"`
 	Contains       []string `mapstructure:"contains"`
 	Equals         []string `mapstructure:"equals"`
+	HasPrefix      []string `mapstructure:"hasPrefix"`
 }
 
 type OutboundProxyConfig struct {

--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -57,6 +57,11 @@ func (config *FilteredRelayConfig) Matches(value map[string]interface{}) (bool, 
 			return true, nil
 		}
 	}
+	for _, val := range config.HasPrefix {
+		if strings.HasPrefix(resultStr, val) {
+			return true, nil
+		}
+	}
 	for _, val := range config.Contains {
 		if strings.Contains(resultStr, val) {
 			return true, nil
@@ -77,7 +82,7 @@ func (config *OutboundProxyConfig) Start() error {
 	}
 
 	for k, v := range config.Relay {
-		log.WithField("path", fmt.Sprintf("/relay/%v", k)).WithField("destinationUrl", v.DestinationURL).WithField("jsonPath", v.JSONPath).WithField("equals", v.Equals).WithField("contains", v.Contains).Info("relay.configured")
+		log.WithField("path", fmt.Sprintf("/relay/%v", k)).WithField("destinationUrl", v.DestinationURL).WithField("jsonPath", v.JSONPath).WithField("equals", v.Equals).WithField("hasPrefix", v.HasPrefix).WithField("contains", v.Contains).Info("relay.configured")
 	}
 
 	// setup http server


### PR DESCRIPTION
This change adds a new `HasPrefix` field to the `FilteredRelayConfig`, which allows a relay endpoint to match & forward a request only if the value at the given JSON path in the request's body starts with at least one of the configured strings defined by the `HasPrefix` rule.

This allows users to create relay configurations which, for example, will only forward requests with a comment body that starts with "/semgrep", while dropping/ignoring requests with a comment body that merely _contains_ "/semgrep" (for example if someone is quoting an earlier comment in the review thread, or instructing on how to use the feature).