### PR TITLE
build image using alpine 3.18.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . ./
 
 RUN go build -o /semgrep-network-broker -ldflags="-X 'github.com/returntocorp/semgrep-network-broker/build.BuildTime=${BUILDTIME}' -X 'github.com/returntocorp/semgrep-network-broker/build.Version=${VERSION}' -X 'github.com/returntocorp/semgrep-network-broker/build.Revision=${REVISION}'"
 
-FROM alpine:latest
+FROM alpine:3.18.3
 
 RUN adduser -D semgrep
 USER semgrep

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . ./
 
 RUN go build -o /semgrep-network-broker -ldflags="-X 'github.com/returntocorp/semgrep-network-broker/build.BuildTime=${BUILDTIME}' -X 'github.com/returntocorp/semgrep-network-broker/build.Version=${VERSION}' -X 'github.com/returntocorp/semgrep-network-broker/build.Revision=${REVISION}'"
 
-FROM alpine:3.17
+FROM alpine:latest
 
 RUN adduser -D semgrep
 USER semgrep


### PR DESCRIPTION
```
% docker build .
[+] Building 11.0s (18/18) FINISHED                                                                                                                                                                                                  docker:orbstack
 => [internal] load build definition from Dockerfile                                                                                                                                                                                            0.0s
 => => transferring dockerfile: 715B                                                                                                                                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                               0.0s
 => => transferring context: 2B                                                                                                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                                                                                                0.0s
 => [internal] load metadata for docker.io/library/golang:1.20-alpine                                                                                                                                                                           0.7s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                                                                                   0.0s
 => [build 1/7] FROM docker.io/library/golang:1.20-alpine@sha256:c63dbdb3cca37abbee4c50f61e34b1d043c2669d03f34485f9ee6fe5feed4e48                                                                                                               0.0s
 => [internal] load build context                                                                                                                                                                                                               0.1s
 => => transferring context: 105.30kB                                                                                                                                                                                                           0.1s
 => [stage-1 1/4] FROM docker.io/library/alpine:latest                                                                                                                                                                                          0.0s
 => [stage-1 2/4] RUN adduser -D semgrep                                                                                                                                                                                                        0.2s
 => CACHED [build 2/7] WORKDIR /app                                                                                                                                                                                                             0.0s
 => CACHED [build 3/7] COPY go.mod ./                                                                                                                                                                                                           0.0s
 => CACHED [build 4/7] COPY go.sum ./                                                                                                                                                                                                           0.0s
 => CACHED [build 5/7] RUN go mod download                                                                                                                                                                                                      0.0s
 => [build 6/7] COPY . ./                                                                                                                                                                                                                       0.8s
 => [stage-1 3/4] WORKDIR /home/semgrep                                                                                                                                                                                                         0.1s
 => [build 7/7] RUN go build -o /semgrep-network-broker -ldflags="-X 'github.com/returntocorp/semgrep-network-broker/build.BuildTime=no-buildtime' -X 'github.com/returntocorp/semgrep-network-broker/build.Version=local-dev' -X 'github.com/  8.8s
 => [stage-1 4/4] COPY --from=build /semgrep-network-broker /usr/bin/semgrep-network-broker                                                                                                                                                     0.0s
 => exporting to image                                                                                                                                                                                                                          0.1s
 => => exporting layers                                                                                                                                                                                                                         0.1s
 => => writing image sha256:6f64fd748b5c397f1b4afd71dc011596e4a15c24ef3df26479afa667cdfa0bfc

% docker run -it --rm --entrypoint /bin/sh 6f64fd748b5c397f1b4afd71dc011596e4a15c24ef3df26479afa667cdfa0bfc -c 'apk list'
WARNING: opening from cache https://dl-cdn.alpinelinux.org/alpine/v3.18/main: No such file or directory
WARNING: opening from cache https://dl-cdn.alpinelinux.org/alpine/v3.18/community: No such file or directory
alpine-baselayout-3.4.3-r1 aarch64 {alpine-baselayout} (GPL-2.0-only) [installed]
alpine-baselayout-data-3.4.3-r1 aarch64 {alpine-baselayout} (GPL-2.0-only) [installed]
alpine-keys-2.4-r1 aarch64 {alpine-keys} (MIT) [installed]
apk-tools-2.14.0-r2 aarch64 {apk-tools} (GPL-2.0-only) [installed]
busybox-1.36.1-r0 aarch64 {busybox} (GPL-2.0-only) [installed]
busybox-binsh-1.36.1-r0 aarch64 {busybox} (GPL-2.0-only) [installed]
ca-certificates-bundle-20230506-r0 aarch64 {ca-certificates} (MPL-2.0 AND MIT) [installed]
libc-utils-0.7.2-r5 aarch64 {libc-dev} (BSD-2-Clause AND BSD-3-Clause) [installed]
libcrypto3-3.1.1-r1 aarch64 {openssl} (Apache-2.0) [installed]
libssl3-3.1.1-r1 aarch64 {openssl} (Apache-2.0) [installed]
musl-1.2.4-r0 aarch64 {musl} (MIT) [installed]
musl-utils-1.2.4-r0 aarch64 {musl} (MIT AND BSD-2-Clause AND GPL-2.0-or-later) [installed]
scanelf-1.3.7-r1 aarch64 {pax-utils} (GPL-2.0-only) [installed]
ssl_client-1.36.1-r0 aarch64 {busybox} (GPL-2.0-only) [installed]
zlib-1.2.13-r1 aarch64 {zlib} (Zlib) [installed]
```