### PR TITLE
add the ability to specify additional fallback relay configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,3 +226,20 @@ outbound:
 would result in requests addressed to http://localhost:8080/relay/test being relayed to https://httpbin.org/anything as long as the result of the jsonpath query `$.foo` executed on the request body results in the string `bar`.
 
 Check out an example [here](./examples/github-pr-comment-relay.yaml) for how to use the relay for GitHub PR comments.
+
+You can also define additional relay mappings via the `additionalConfigs` field:
+
+```yaml
+outbound:
+  listenPort: 8080
+  relay:
+    test:
+      destinationUrl: https://httpbin.org/anything
+      jsonPath: "$.foo"
+      equals:
+      - bar
+      additionalConfigs:
+      - destinationUrl: htttps://example.com/fallback
+```
+
+The example above would relay traffic to https://httpbin.org/anything if the request body contains `{"foo": "bar"}`, otherwise, it'd relay traffic to `htttps://example.com/fallback`.

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -216,11 +216,12 @@ type InboundProxyConfig struct {
 }
 
 type FilteredRelayConfig struct {
-	DestinationURL string   `mapstructure:"destinationUrl"`
-	JSONPath       string   `mapstructure:"jsonPath"`
-	Contains       []string `mapstructure:"contains"`
-	Equals         []string `mapstructure:"equals"`
-	HasPrefix      []string `mapstructure:"hasPrefix"`
+	DestinationURL    string                `mapstructure:"destinationUrl"`
+	JSONPath          string                `mapstructure:"jsonPath"`
+	Contains          []string              `mapstructure:"contains"`
+	Equals            []string              `mapstructure:"equals"`
+	HasPrefix         []string              `mapstructure:"hasPrefix"`
+	AdditionalConfigs []FilteredRelayConfig `mapstructure:"additionalConfigs"` // this is awful, but we can refactor this in the near future
 }
 
 type OutboundProxyConfig struct {

--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -67,6 +67,14 @@ func (config *FilteredRelayConfig) Matches(value map[string]interface{}) (bool, 
 			return true, nil
 		}
 	}
+
+	for i := range config.AdditionalConfigs {
+		inner_match, inner_err := config.AdditionalConfigs[i].Matches(value)
+		if inner_match || inner_err != nil {
+			return inner_match, inner_err
+		}
+	}
+
 	return false, nil
 }
 


### PR DESCRIPTION
A little janky, but this PR gives us the ability to define a list of fallback relay configs. I'll refactor the config in the near future to make this cleaner -- there are several changes I'd like to make.