### PR TITLE
header matching + fix match logic + e2e test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
@@ -43,6 +44,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
@@ -51,6 +53,8 @@ require (
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -285,6 +285,7 @@ github.com/spf13/viper v1.16.0/go.mod h1:yg78JgCJcbrQOvV9YLXgkLaZqUidkY9K+Dd1Fof
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -297,6 +298,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=

--- a/it/e2e_test.go
+++ b/it/e2e_test.go
@@ -233,13 +233,13 @@ func TestRelay(t *testing.T) {
 					DestinationURL: internalServer.URL,
 					JSONPath:       "$.comment.body",
 					Contains:       []string{"/semgrep"},
-					HeadersContains: map[string]string{
+					HeaderEquals: map[string]string{
 						"X-GitHub-Event": "pull_request_review_comment",
 					},
 					AdditionalConfigs: []pkg.FilteredRelayConfig{
 						{
 							DestinationURL: internalServer2.URL,
-							HeadersNotContains: map[string]string{
+							HeaderNotEquals: map[string]string{
 								"X-GitHub-Event": "pull_request_review_comment",
 							},
 						},

--- a/it/e2e_test.go
+++ b/it/e2e_test.go
@@ -303,9 +303,9 @@ func TestRelay(t *testing.T) {
 	resp, _ = http.DefaultClient.Do(req)
 	buf := new(strings.Builder)
 	io.Copy(buf, resp.Body)
-	assert.Equal(200, resp.StatusCode, "non-semgrep comment should return 200")
+	assert.Equal(200, resp.StatusCode, "semgrep comment should return 200")
 	assert.Equal("1", resp.Header.Get("X-Semgrep-Network-Broker-Relay-Match"), "semgrep comment should match")
-	assert.Equal("Server1", buf.String(), "request should be relayed to Server1")
+	assert.Equal("Server1", buf.String(), "semgrep comment should be relayed to Server1")
 
 	req = &http.Request{
 		Method: "POST",
@@ -320,5 +320,5 @@ func TestRelay(t *testing.T) {
 	io.Copy(bodyBuilder, resp.Body)
 	assert.Equal(200, resp.StatusCode, "other event should return 200")
 	assert.Equal("1", resp.Header.Get("X-Semgrep-Network-Broker-Relay-Match"), "other event should match")
-	assert.Equal("Server2", bodyBuilder.String(), "other event should hit other server")
+	assert.Equal("Server2", bodyBuilder.String(), "other event should be relayed to Server2")
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -221,6 +221,8 @@ type FilteredRelayConfig struct {
 	Contains          []string              `mapstructure:"contains"`
 	Equals            []string              `mapstructure:"equals"`
 	HasPrefix         []string              `mapstructure:"hasPrefix"`
+	HeaderEquals      map[string]string     `mapstructure:"headerEquals"`
+	HeaderNotEquals   map[string]string     `mapstructure:"headerNotEquals"`
 	AdditionalConfigs []FilteredRelayConfig `mapstructure:"additionalConfigs"` // this is awful, but we can refactor this in the near future
 }
 


### PR DESCRIPTION
- We need to additionally be able to match on headers because GitHub events only specify the event type in the HTTP header.
- Update match logic to handle jsonpath bodies and headers
- Add e2e test
