### PR TITLE
github org was renamed from returntocorp to semgrep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 
 COPY . ./
 
-RUN go build -o /semgrep-network-broker -ldflags="-X 'github.com/returntocorp/semgrep-network-broker/build.BuildTime=${BUILDTIME}' -X 'github.com/returntocorp/semgrep-network-broker/build.Version=${VERSION}' -X 'github.com/returntocorp/semgrep-network-broker/build.Revision=${REVISION}'"
+RUN go build -o /semgrep-network-broker -ldflags="-X 'github.com/semgrep/semgrep-network-broker/build.BuildTime=${BUILDTIME}' -X 'github.com/semgrep/semgrep-network-broker/build.Version=${VERSION}' -X 'github.com/semgrep/semgrep-network-broker/build.Revision=${REVISION}'"
 
 FROM alpine:3.18.3
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ deps:
 	go mod download
 
 build: deps
-	go build -o bin/$(BINARY_NAME) -ldflags="-X 'github.com/returntocorp/semgrep-network-broker/build.BuildTime=$(BUILDTIME)' -X 'github.com/returntocorp/semgrep-network-broker/build.Version=$(VERSION)' -X 'github.com/returntocorp/semgrep-network-broker/build.Revision=$(REVISION)'"
+	go build -o bin/$(BINARY_NAME) -ldflags="-X 'github.com/semgrep/semgrep-network-broker/build.BuildTime=$(BUILDTIME)' -X 'github.com/semgrep/semgrep-network-broker/build.Version=$(VERSION)' -X 'github.com/semgrep/semgrep-network-broker/build.Revision=$(REVISION)'"
 
 docker:
 	docker build --build-arg BUILDTIME=$(BUILDTIME) --build-arg VERSION=$(VERSION) --build-arg REVISION=$(REVISION) -t semgrep-network-broker .

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Examples of inbound traffic include:
 
 - Run `make build` to generate the `semgrep-network-broker` binary
 - Run `make docker` to generate a docker image
-- Docker images are also published to [ghcr.io/returntocorp/semgrep-network-broker](https://github.com/returntocorp/semgrep-network-broker/pkgs/container/semgrep-network-broker)
+- Docker images are also published to [ghcr.io/semgrep/semgrep-network-broker](https://github.com/semgrep/semgrep-network-broker/pkgs/container/semgrep-network-broker)
 
 ### Keypairs
 

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/returntocorp/semgrep-network-broker/pkg"
+	"github.com/semgrep/semgrep-network-broker/pkg"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/returntocorp/semgrep-network-broker/pkg"
+	"github.com/semgrep/semgrep-network-broker/pkg"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,8 +9,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/returntocorp/semgrep-network-broker/build"
-	"github.com/returntocorp/semgrep-network-broker/pkg"
+	"github.com/semgrep/semgrep-network-broker/build"
+	"github.com/semgrep/semgrep-network-broker/pkg"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/returntocorp/semgrep-network-broker
+module github.com/semgrep/semgrep-network-broker
 
 go 1.21
 

--- a/it/e2e_test.go
+++ b/it/e2e_test.go
@@ -15,8 +15,8 @@ import (
 	"time"
 
 	"github.com/mcuadros/go-defaults"
-	"github.com/returntocorp/semgrep-network-broker/cmd"
-	"github.com/returntocorp/semgrep-network-broker/pkg"
+	"github.com/semgrep/semgrep-network-broker/cmd"
+	"github.com/semgrep/semgrep-network-broker/pkg"
 	"github.com/stretchr/testify/assert"
 
 	log "github.com/sirupsen/logrus"

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/returntocorp/semgrep-network-broker/cmd"
+import "github.com/semgrep/semgrep-network-broker/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Update code and docs to reflect the fact that the GitHub org is now "semgrep" (was previously "returntocorp")

Fixes https://github.com/semgrep/semgrep-network-broker/issues/53