### PR TITLE
run tests on pull_request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,11 @@ name: test
 on:
   workflow_dispatch:
   push:
+    branches:
+      - develop
+    tags:
+      - v*
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Trigger on `pull_request` rather than `push` so that we can require in branch protection rules.