### PR TITLE
add more urls to default ghe allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Under the hood, this config adds these allowlist items:
 - GET `https://github.example.com/api/v3/repos/:owner/:repo`
 - GET `https://github.example.com/api/v3/repos/:owner/:repo/pulls`
 - GET `https://github.example.com/api/v3/orgs/:org/installation`
+- GET `https://github.example.com/api/v3/orgs/:org/installation/repositories`
+- GET `https://github.example.com/api/v3/app`
+- POST `https://github.example.com/api/v3/app-manifests/:code/conversions`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/pulls/:number/comments`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/issues/:number/comments`
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -308,6 +308,24 @@ func LoadConfig(configFiles []string) (*Config, error) {
 				URL:               gitHubBaseUrl.JoinPath("/orgs/:org/installation").String(),
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
+			},
+			// check repo installation
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/orgs/:org/installation/repositories").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
+			// initiate app installation
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/app-manifests/:code/conversions").String(),
+				Methods:           ParseHttpMethods([]string{"POST"}),
+				SetRequestHeaders: headers,
+			},
+			// get app installation
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/app").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
 			})
 	}
 


### PR DESCRIPTION
We added a url to check GHE app installation in the default GH allowlist in the previous PR. I completely missed some of the URLs we need for app creation and checking installations on specific repos.