### PR TITLE
add github urls for personal accounts to the allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Under the hood, this config adds these allowlist items:
 - GET `https://github.example.com/api/v3/repos/:owner/:repo/pulls`
 - GET `https://github.example.com/api/v3/orgs/:org/installation`
 - GET `https://github.example.com/api/v3/orgs/:org/installation/repositories`
+- GET `https://github.example.com/api/v3/users/:user/installation`
+- GET `https://github.example.com/api/v3/users/:user/installation/repositories`
 - GET `https://github.example.com/api/v3/app`
 - POST `https://github.example.com/api/v3/app-manifests/:code/conversions`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/pulls/:number/comments`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -317,7 +317,7 @@ func LoadConfig(configFiles []string) (*Config, error) {
 			},
 			// check app installation for a personal account
 			AllowlistItem{
-				URL:               gitHubBaseUrl.JoinPath("/users/:user/installation/repositories").String(),
+				URL:               gitHubBaseUrl.JoinPath("/users/:user/installation").String(),
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -303,15 +303,27 @@ func LoadConfig(configFiles []string) (*Config, error) {
 				Methods:           ParseHttpMethods([]string{"POST"}),
 				SetRequestHeaders: headers,
 			},
-			// check app installation
+			// check app installation for an org
 			AllowlistItem{
 				URL:               gitHubBaseUrl.JoinPath("/orgs/:org/installation").String(),
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
-			// check repo installation
+			// check repo installation for an org
 			AllowlistItem{
 				URL:               gitHubBaseUrl.JoinPath("/orgs/:org/installation/repositories").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
+			// check app installation for a personal account
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/users/:user/installation/repositories").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
+			// check repo installation for a personal account
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/users/:user/installation/repositories").String(),
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},


### PR DESCRIPTION
We added github organization urls in the previous PR. The last thing we are missing is adding the urls for the personal accounts and push out a new version of the image.