### PR TITLE
use basic auth in proxied request, if set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
+	github.com/whuang8/redactrus v1.0.2 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/arch v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,8 @@ github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb h1:Ywfo8sUltxogBpF
 github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb/go.mod h1:ikPs9bRWicNw3S7XpJ8sK/smGwU9WcSVU3dy9qahYBM=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/whuang8/redactrus v1.0.2 h1:F6h9zpN/eJDAkFSZmCT97m52Cr0r7FnDwSw1Y2wRLsA=
+github.com/whuang8/redactrus v1.0.2/go.mod h1:/QqU95wNV2zWg3nD5/uatl9Uz0cJUROT4Svx4PoT78Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,25 @@
 package main
 
-import "github.com/semgrep/semgrep-network-broker/cmd"
+import (
+	"github.com/semgrep/semgrep-network-broker/cmd"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/whuang8/redactrus"
+)
+
+
+func init() {
+	// Create Redactrus hook that is triggered
+	// for every logger level and redacts
+	// github oauth tokens from logs
+	// regex source: https://gist.github.com/magnetikonline/073afe7909ffdd6f10ef06a00bc3bc88
+	rh := &redactrus.Hook{
+			AcceptedLevels: log.AllLevels,
+			RedactionList:  []string{"^(gh[ps]_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})$"},
+	}
+
+	log.AddHook(rh)
+}
 
 func main() {
 	cmd.Execute()

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func init() {
 	// regex source: https://gist.github.com/magnetikonline/073afe7909ffdd6f10ef06a00bc3bc88
 	rh := &redactrus.Hook{
 			AcceptedLevels: log.AllLevels,
-			RedactionList:  []string{"^(gh[ps]_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})$"},
+			RedactionList:  []string{"(oauth2:)^(gh[ps]_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})$(@)"},
 	}
 
 	log.AddHook(rh)

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func init() {
 	// regex source: https://gist.github.com/magnetikonline/073afe7909ffdd6f10ef06a00bc3bc88
 	rh := &redactrus.Hook{
 			AcceptedLevels: log.AllLevels,
-			RedactionList:  []string{"(oauth2:)^(gh[ps]_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})$(@)"},
+			RedactionList:  []string{"(oauth2:)gh[ps]_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}(@)"},
 	}
 
 	log.AddHook(rh)

--- a/pkg/inbound_proxy.go
+++ b/pkg/inbound_proxy.go
@@ -100,6 +100,14 @@ func (config *InboundProxyConfig) Start(tnet *netstack.Net) error {
 			Director: func(req *http.Request) {
 				req.URL = destinationUrl
 				req.Host = destinationUrl.Host
+				if destinationUrl.User != nil {
+					destPassword, exists := destinationUrl.User.Password()
+					if exists {
+						req.SetBasicAuth(destinationUrl.User.Username(), destPassword)
+					} else {
+						req.SetBasicAuth(destinationUrl.User.Username(), "")
+					}
+				}
 				for headerName, headerValue := range allowlistMatch.SetRequestHeaders {
 					req.Header.Set(headerName, headerValue)
 				}


### PR DESCRIPTION
1. Use basic auth for proxied requests
2. Redact the oauth2 access token used for cloning api requests.

Merging this in for now but a follow-up to this is that all the proxied requests should really carry over the auth from the original requests. Right now, we are just manually parsing out the basic auth to unblock the ZCS cloning work.