### PR TITLE
optionally load default configs from semgrep

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -13,7 +13,7 @@ var dumpCmd = &cobra.Command{
 	Use:   "dump",
 	Short: "Dump current config",
 	Run: func(cmd *cobra.Command, args []string) {
-		config, err := pkg.LoadConfig(configFiles)
+		config, err := pkg.LoadConfig(configFiles, deploymentId)
 		if err != nil {
 			log.Panic(err)
 		}

--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -30,7 +30,7 @@ var relayCmd = &cobra.Command{
 		}()
 
 		// load config(s)
-		config, err := pkg.LoadConfig(configFiles)
+		config, err := pkg.LoadConfig(configFiles, 0)
 		if err != nil {
 			log.Panic(err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ import (
 
 var configFiles []string
 var jsonLog bool
+var deploymentId int
 
 var rootCmd = &cobra.Command{
 	Use:     "semgrep-network-broker",
@@ -38,7 +39,7 @@ var rootCmd = &cobra.Command{
 		}()
 
 		// load config(s)
-		config, err := pkg.LoadConfig(configFiles)
+		config, err := pkg.LoadConfig(configFiles, deploymentId)
 		if err != nil {
 			log.Panic(err)
 		}
@@ -93,4 +94,5 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().StringArrayVarP(&configFiles, "config", "c", nil, "config file(s)")
 	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", false, "JSON log output")
+	rootCmd.PersistentFlags().IntVarP(&deploymentId, "deployment-id", "d", 0, "Semgrep deployment ID")
 }

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestEmptyConfigs(t *testing.T) {
-	config, err := LoadConfig(nil)
+	config, err := LoadConfig(nil, 0)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
- passing `-d` or `--deployment-id` will have the broker load default configs from `https://semgrep.dev/api/broker/$DEPLOYMENT_ID/default-config` (common / non-sensitive configs only)
- semgrep hostname can be overridden by the `SEMGREP_HOSTNAME` env var (e.g. use `SEMGREP_HOSTNAME=foo.semgrep.dev` for the `foo` tenant)
