### PR TITLE
Add /namespace to GitLab allowlist for SCM driver v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ inbound:
 
 Under the hood, this config adds these allowlist items:
 
+- GET `https://gitlab.example.com/api/v4/namespaces/:namespace`
 - GET `https://gitlab.example.com/api/v4/projects/:project`
 - GET `https://gitlab.example.com/api/v4/projects/:project/merge_requests`
 - GET `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/versions`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -412,6 +412,12 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 		}
 
 		config.Inbound.Allowlist = append(config.Inbound.Allowlist,
+			// Group info
+			AllowlistItem{
+				URL:               gitLabBaseUrl.JoinPath("/namespaces/:namespace").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
 			// repo info
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/projects/:project").String(),


### PR DESCRIPTION
The v2 SCM driver in the app uses this namespaces URL as well: ref `.../scm/drivers_v2/gitlab.py` in the app code.

One thing I'm unsure of here is whether it's adequate to just name the parameter `:namespace` - I could not identify for sure if these parameters need to follow certain patterns.