### PR TITLE
GitHub SCM: Add app installation access token endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Under the hood, this config adds these allowlist items:
 - GET `https://github.example.com/api/v3/users/:user/installation`
 - GET `https://github.example.com/api/v3/users/:user/installation/repositories`
 - GET `https://github.example.com/api/v3/app`
+- POST `https://github.example.com/api/v3/app/installations/:id/access_tokens
 - POST `https://github.example.com/api/v3/app-manifests/:code/conversions`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/pulls/:number/comments`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/issues/:number/comments`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -393,7 +393,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				URL:               gitHubBaseUrl.JoinPath("/app").String(),
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
-			})
+			},
 			AllowlistItem{
 				URL:               gitHubBaseUrl.JoinPath("/app/installations/:id/access_tokens").String(),
 				Methods:           ParseHttpMethods([]string{"POST"}),

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -394,6 +394,11 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			})
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/app/installations/:id/access_tokens").String(),
+				Methods:           ParseHttpMethods([]string{"POST"}),
+				SetRequestHeaders: headers,
+			})
 
 		if config.Inbound.GitHub.AllowCodeAccess {
 			config.Inbound.Allowlist = append(config.Inbound.Allowlist,


### PR DESCRIPTION
This URL is used in the SCM driver for GitHub in the Semgrep AppSec Platform, so should also be in the default allowlist.
[Code link](https://github.com/semgrep/semgrep-app/blob/develop/server/semgrep_app/foundations/scm/drivers_v2/github.py#L258) (🔒)