### PR TITLE
Fix missing backtick on new allowlist URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Under the hood, this config adds these allowlist items:
 - GET `https://github.example.com/api/v3/users/:user/installation`
 - GET `https://github.example.com/api/v3/users/:user/installation/repositories`
 - GET `https://github.example.com/api/v3/app`
-- POST `https://github.example.com/api/v3/app/installations/:id/access_tokens
+- POST `https://github.example.com/api/v3/app/installations/:id/access_tokens`
 - POST `https://github.example.com/api/v3/app-manifests/:code/conversions`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/pulls/:number/comments`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/issues/:number/comments`


### PR DESCRIPTION
Fix a backtick I missed in my last PR.