### PR TITLE
Replace installation repos with org repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Under the hood, this config adds these allowlist items:
 - GET `https://github.example.com/api/v3/repos/:owner/:repo`
 - GET `https://github.example.com/api/v3/repos/:owner/:repo/pulls`
 - GET `https://github.example.com/api/v3/orgs/:org/installation`
-- GET `https://github.example.com/api/v3/orgs/:org/installation/repositories`
+- GET `https://github.example.com/api/v3/orgs/:org/repos`
 - GET `https://github.example.com/api/v3/users/:user/installation`
 - GET `https://github.example.com/api/v3/users/:user/installation/repositories`
 - GET `https://github.example.com/api/v3/app`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -364,9 +364,9 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
-			// check repo installation for an org
+			// check repos for an org
 			AllowlistItem{
-				URL:               gitHubBaseUrl.JoinPath("/orgs/:org/installation/repositories").String(),
+				URL:               gitHubBaseUrl.JoinPath("/orgs/:org/repos").String(),
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},


### PR DESCRIPTION
The SCM drivers in the app now use the org repos endpoint, rather than the installation repos endpoint. 🔒 [Code change](https://github.com/semgrep/semgrep-app/commit/8360fd558bce3e6fa7387e1174b967b932583da3)

This PR updates the GitHub default allowlist accordingly.