### PR TITLE
chore: add webhook API urls and project API urls for Gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,20 @@ inbound:
 
 Under the hood, this config adds these allowlist items:
 
+- DELETE `https://gitlab.example.com/api/v4/groups/:namespace/hooks/:hook`
+- DELETE `https://gitlab.example.com/api/v4/projects/:project/hooks/:hook`
+- GET `https://gitlab.example.com/api/v4/groups/:namespace/hooks`
 - GET `https://gitlab.example.com/api/v4/namespaces/:namespace`
 - GET `https://gitlab.example.com/api/v4/projects/:project`
+- GET `https://gitlab.example.com/api/v4/projects/:project/members/all/:user`
 - GET `https://gitlab.example.com/api/v4/projects/:project/merge_requests`
 - GET `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/versions`
 - GET `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions`
+- GET `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions/:discussion/notes/:note/award_emoji`
 - GET `https://gitlab.example.com/api/v4/projects/:project/repository/branches`
 - GET `https://gitlab.example.com/api/v4/:entity_type/:namespace/projects`
+- POST `https://gitlab.example.com/api/v4/groups/:namespace/hooks`
+- POST `https://gitlab.example.com/api/v4/projects/:project/hooks`
 - POST `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions`
 - POST `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions/:discussion/notes`
 - PUT `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions/:discussion/notes/:note`
@@ -141,6 +148,8 @@ And if `allowCodeAccess` is set, additionally:
 
 - GET `https://gitlab.example.com/api/v4/projects/:project/repository/files/:filepath`
 - GET `https://gitlab.example.com/api/v4/projects/:project/repository/commits`
+- GET `https://gitlab.example.com/api/v4/projects/:project/repository/compare`
+- POST `https://gitlab.example.com/api/v4/projects/:project/statuses/:commit`
 
 ### Bitbucket
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -436,6 +436,17 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 		}
 
 		config.Inbound.Allowlist = append(config.Inbound.Allowlist,
+			// Group webhooks
+			AllowlistItem{
+				URL:               gitLabBaseUrl.JoinPath("/groups/:namespace/hooks").String(),
+				Methods:           ParseHttpMethods([]string{"GET", "POST"}),
+				SetRequestHeaders: headers,
+			},
+			AllowlistItem{
+				URL:               gitLabBaseUrl.JoinPath("/groups/:namespace/hooks/:hook").String(),
+				Methods:           ParseHttpMethods([]string{"DELETE"}),
+				SetRequestHeaders: headers,
+			},
 			// Group info
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/namespaces/:namespace").String(),
@@ -445,6 +456,23 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 			// repo info
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/projects/:project").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
+			// Repo webhooks
+			AllowlistItem{
+				URL:               gitLabBaseUrl.JoinPath("/projects/:project/hooks").String(),
+				Methods:           ParseHttpMethods([]string{"POST"}),
+				SetRequestHeaders: headers,
+			},
+			AllowlistItem{
+				URL:               gitLabBaseUrl.JoinPath("/projects/:project/hooks/:hook").String(),
+				Methods:           ParseHttpMethods([]string{"DELETE"}),
+				SetRequestHeaders: headers,
+			},
+			// Get a repo member
+			AllowlistItem{
+				URL:               gitLabBaseUrl.JoinPath("/projects/:project/members/all/:user").String(),
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
@@ -496,6 +524,12 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				Methods:           ParseHttpMethods([]string{"PUT"}),
 				SetRequestHeaders: headers,
 			},
+			// Get reactions to comments
+			AllowlistItem{
+				URL:               gitLabBaseUrl.JoinPath("/projects/:project/merge_requests/:number/discussions/:discussion/notes/:note/award_emoji").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
 		)
 
 		if config.Inbound.GitLab.AllowCodeAccess {
@@ -509,6 +543,18 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				// Commits
 				AllowlistItem{
 					URL:               gitLabBaseUrl.JoinPath("/projects/:project/repository/commits").String(),
+					Methods:           ParseHttpMethods([]string{"GET"}),
+					SetRequestHeaders: headers,
+				},
+				// Compare branches
+				AllowlistItem{
+					URL:               gitLabBaseUrl.JoinPath("/projects/:project/repository/compare").String(),
+					Methods:           ParseHttpMethods([]string{"GET"}),
+					SetRequestHeaders: headers,
+				},
+				// Update commit status
+				AllowlistItem{
+					URL:               gitLabBaseUrl.JoinPath("/projects/:project/statuses/:commit").String(),
 					Methods:           ParseHttpMethods([]string{"GET"}),
 					SetRequestHeaders: headers,
 				},


### PR DESCRIPTION
We have been adding new features that use Gitlab APIs that are not on the allowlist yet:
- Webhooks
- Retrieve a repo member
- Fetch comment reactions
- Compare branches
- Update commit statuses

This PR is to update the Gitlab config and README with the urls.