### PR TITLE
better support for running multiple separate brokers

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -13,7 +13,7 @@ var dumpCmd = &cobra.Command{
 	Use:   "dump",
 	Short: "Dump current config",
 	Run: func(cmd *cobra.Command, args []string) {
-		config, err := pkg.LoadConfig(configFiles, deploymentId)
+		config, err := pkg.LoadConfig(configFiles, deploymentId, brokerIndex)
 		if err != nil {
 			log.Panic(err)
 		}

--- a/cmd/genkey.go
+++ b/cmd/genkey.go
@@ -6,22 +6,37 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.zx2c4.com/wireguard/device"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
+
+var keyCount int
+
+const defaultKeyCount = 3
 
 var genkeyCmd = &cobra.Command{
 	Use:   "genkey",
 	Short: "Generates a random private key in base64 and prints it to stdout",
 	Run: func(cmd *cobra.Command, args []string) {
-		privateKey, err := wgtypes.GeneratePrivateKey()
-		if err != nil {
-			log.Panic(fmt.Errorf("failed to generate private key: %v", err))
+		if keyCount < 1 {
+			log.Panic("--key-count must be greater than zero")
 		}
 
-		fmt.Println(base64.StdEncoding.EncodeToString(privateKey[:]))
+		result := make([]byte, 0, device.NoisePrivateKeySize*keyCount)
+
+		for i := 0; i < keyCount; i++ {
+			privateKey, err := wgtypes.GeneratePrivateKey()
+			if err != nil {
+				log.Panic(fmt.Errorf("failed to generate private key: %v", err))
+			}
+			result = append(result[:], privateKey[:]...)
+		}
+
+		fmt.Println(base64.StdEncoding.EncodeToString(result))
 	},
 }
 
 func init() {
+	genkeyCmd.PersistentFlags().IntVarP(&keyCount, "key-count", "k", defaultKeyCount, "Number of keys to generate")
 	rootCmd.AddCommand(genkeyCmd)
 }

--- a/cmd/pubkey.go
+++ b/cmd/pubkey.go
@@ -8,6 +8,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.zx2c4.com/wireguard/device"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
@@ -20,23 +21,27 @@ var pubkeyCmd = &cobra.Command{
 			log.Panic(err)
 		}
 
-		keyBytes := make([]byte, 32)
+		keyBytes := make([]byte, defaultKeyCount*device.NoisePrivateKeySize)
 		n, err := base64.StdEncoding.Decode(keyBytes, keyBase64)
 		if err != nil {
 			log.Panic(err)
 		}
-		if n != 32 {
-			log.Panic("not enough bytes")
+		if n%device.NoisePrivateKeySize != 0 {
+			log.Panicf("invalid byte length: %v", n)
 		}
 
-		privateKey, err := wgtypes.NewKey(keyBytes)
-		if err != nil {
-			log.Panic(err)
+		result := make([]byte, 0, n)
+
+		for i := 0; i < n; i += device.NoisePrivateKeySize {
+			privateKey, err := wgtypes.NewKey(keyBytes[i : i+device.NoisePrivateKeySize])
+			if err != nil {
+				log.Panic(err)
+			}
+			publicKey := privateKey.PublicKey()
+			result = append(result, publicKey[:]...)
 		}
 
-		publicKey := privateKey.PublicKey()
-
-		fmt.Println(base64.StdEncoding.EncodeToString(publicKey[:]))
+		fmt.Println(base64.StdEncoding.EncodeToString(result))
 	},
 }
 

--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -30,7 +30,7 @@ var relayCmd = &cobra.Command{
 		}()
 
 		// load config(s)
-		config, err := pkg.LoadConfig(configFiles, 0)
+		config, err := pkg.LoadConfig(configFiles, 0, 0)
 		if err != nil {
 			log.Panic(err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 var configFiles []string
 var jsonLog bool
 var deploymentId int
+var brokerIndex int
 
 var rootCmd = &cobra.Command{
 	Use:     "semgrep-network-broker",
@@ -39,7 +40,7 @@ var rootCmd = &cobra.Command{
 		}()
 
 		// load config(s)
-		config, err := pkg.LoadConfig(configFiles, deploymentId)
+		config, err := pkg.LoadConfig(configFiles, deploymentId, brokerIndex)
 		if err != nil {
 			log.Panic(err)
 		}
@@ -75,7 +76,7 @@ func StartNetworkBroker(config *pkg.Config) (func() error, error) {
 		return wireguardTeardown()
 	}
 
-	// start inbound proxy (r2c --> customer)
+	// start inbound proxy (semgrep --> customer)
 	if err := config.Inbound.Start(tnet); err != nil {
 		teardown()
 		return nil, fmt.Errorf("failed to start inbound proxy: %v", err)
@@ -95,4 +96,5 @@ func init() {
 	rootCmd.PersistentFlags().StringArrayVarP(&configFiles, "config", "c", nil, "config file(s)")
 	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", false, "JSON log output")
 	rootCmd.PersistentFlags().IntVarP(&deploymentId, "deployment-id", "d", 0, "Semgrep deployment ID")
+	rootCmd.PersistentFlags().IntVarP(&brokerIndex, "broker-index", "i", 0, "Semgrep network broker index")
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"reflect"
@@ -72,13 +73,15 @@ type WireguardPeer struct {
 }
 
 type WireguardBase struct {
-	LocalAddress string                `mapstructure:"localAddress" json:"localAddress" validate:"format=ip"`
-	Dns          []string              `mapstructure:"dns" json:"dns" validate:"empty=true > format=ip"`
-	Mtu          int                   `mapstructure:"mtu" json:"mtu" validate:"gte=0" default:"1420"`
-	PrivateKey   SensitiveBase64String `mapstructure:"privateKey" json:"privateKey" validate:"empty=false"`
-	ListenPort   int                   `mapstructure:"listenPort" json:"listenPort" validate:"gte=0"`
-	Peers        []WireguardPeer       `mapstructure:"peers" json:"peers" validate:"empty=false"`
-	Verbose      bool                  `mapstructure:"verbose" json:"verbose"`
+	resolvedLocalAddress netip.Addr
+	LocalAddress         string                `mapstructure:"localAddress" json:"localAddress" validate:"format=ip"`
+	Dns                  []string              `mapstructure:"dns" json:"dns" validate:"empty=true > format=ip"`
+	Mtu                  int                   `mapstructure:"mtu" json:"mtu" validate:"gte=0" default:"1420"`
+	PrivateKey           SensitiveBase64String `mapstructure:"privateKey" json:"privateKey" validate:"empty=false"`
+	ListenPort           int                   `mapstructure:"listenPort" json:"listenPort" validate:"gte=0"`
+	Peers                []WireguardPeer       `mapstructure:"peers" json:"peers" validate:"empty=false"`
+	Verbose              bool                  `mapstructure:"verbose" json:"verbose"`
+	BrokerIndex          int                   `mapstructure:"brokerIndex" json:"brokerIndex" validate:"gte=0"`
 }
 
 type BitTester interface {
@@ -262,8 +265,10 @@ type Config struct {
 	Outbound OutboundProxyConfig `mapstructure:"outbound" json:"outbound"`
 }
 
-func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
+func LoadConfig(configFiles []string, deploymentId int, brokerIndex int) (*Config, error) {
 	config := new(Config)
+
+	config.Inbound.Wireguard.BrokerIndex = brokerIndex
 
 	if deploymentId > 0 {
 		hostname := os.Getenv("SEMGREP_HOSTNAME")

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestEmptyConfigs(t *testing.T) {
-	config, err := LoadConfig(nil, 0)
+	config, err := LoadConfig(nil, 0, 0)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/wireguard.go
+++ b/pkg/wireguard.go
@@ -48,7 +48,9 @@ func (base WireguardBase) Validate() error {
 func (base WireguardBase) GenerateConfig() string {
 	sb := strings.Builder{}
 
-	sb.WriteString(fmt.Sprintf("private_key=%s\n", hex.EncodeToString(base.PrivateKey[device.NoisePrivateKeySize*base.BrokerIndex:device.NoisePrivateKeySize*(base.BrokerIndex+1)])))
+	indexedPrivateKey := base.PrivateKey[device.NoisePrivateKeySize*base.BrokerIndex : device.NoisePrivateKeySize*(base.BrokerIndex+1)]
+
+	sb.WriteString(fmt.Sprintf("private_key=%s\n", hex.EncodeToString(indexedPrivateKey)))
 	sb.WriteString(fmt.Sprintf("listen_port=%d\n", base.ListenPort))
 
 	for i := range base.Peers {

--- a/pkg/wireguard.go
+++ b/pkg/wireguard.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -34,10 +35,20 @@ func (peer WireguardPeer) WriteTo(sb io.StringWriter) {
 	}
 }
 
+func (base WireguardBase) Validate() error {
+	privateKeyCount := len(base.PrivateKey) / device.NoisePrivateKeySize
+
+	if base.BrokerIndex >= privateKeyCount {
+		return errors.New("broker index beyond private key count")
+	}
+
+	return nil
+}
+
 func (base WireguardBase) GenerateConfig() string {
 	sb := strings.Builder{}
 
-	sb.WriteString(fmt.Sprintf("private_key=%s\n", hex.EncodeToString(base.PrivateKey)))
+	sb.WriteString(fmt.Sprintf("private_key=%s\n", hex.EncodeToString(base.PrivateKey[device.NoisePrivateKeySize*base.BrokerIndex:device.NoisePrivateKeySize*(base.BrokerIndex+1)])))
 	sb.WriteString(fmt.Sprintf("listen_port=%d\n", base.ListenPort))
 
 	for i := range base.Peers {
@@ -47,7 +58,16 @@ func (base WireguardBase) GenerateConfig() string {
 	return sb.String()
 }
 
-func (base *WireguardBase) ResolvePeerEndpoints() error {
+func (base *WireguardBase) ResolveConfig() error {
+	resolvedLocalAddress, err := netip.ParseAddr(base.LocalAddress)
+	if err != nil {
+		return fmt.Errorf("LocalAddress parse failed: %v", err)
+	}
+	for i := 0; i < base.BrokerIndex; i++ {
+		resolvedLocalAddress = resolvedLocalAddress.Next()
+	}
+	base.resolvedLocalAddress = resolvedLocalAddress
+
 	for i := range base.Peers {
 		if base.Peers[i].Endpoint == "" {
 			continue
@@ -77,13 +97,10 @@ func (config *WireguardBase) Start() (*netstack.Net, func() error, error) {
 		return nil, nil, fmt.Errorf("invalid wireguard config: %v", err)
 	}
 
-	// resolve peer endpoints (if not IP address already)
-	if err := config.ResolvePeerEndpoints(); err != nil {
+	// resolve local address and peer endpoints (if not IP address already)
+	if err := config.ResolveConfig(); err != nil {
 		return nil, nil, fmt.Errorf("failed to resolve peer endpoint: %v", err)
 	}
-
-	// parse localAddres and DNS addresses -- MustParseAddr is fine here because we've already validated the config
-	localAddress := netip.MustParseAddr(config.LocalAddress)
 
 	var dnsAddresses = make([]netip.Addr, len(config.Dns))
 	for i := range config.Dns {
@@ -92,7 +109,7 @@ func (config *WireguardBase) Start() (*netstack.Net, func() error, error) {
 
 	// create the wireguard interface
 	tun, tnet, err := netstack.CreateNetTUN(
-		[]netip.Addr{localAddress},
+		[]netip.Addr{config.resolvedLocalAddress},
 		dnsAddresses,
 		config.Mtu,
 	)


### PR DESCRIPTION
This PR lays the foundation for cleanly supporting multiple broker replicas for an organization. The current problems are:
1. Running identical replicas cause the brokers to fight between one another for who "owns" the peer connection. It's possible that requests can fail during some of the ownership transition periods.
2. Running multiple replicas with different peer addresses but identical keypairs doen't work -- wireguard expects each keypair to be unique
3. Running multiple replicas with same peer address but different keypairs would work, but they'd still fight over which peer connection is which

The solution we're going with is to concatenate multiple keys together into one mega key, and then use a new config field (`inbound.wireguard.brokerIndex` in config or `--broker-index` on the command line) to select which offset key and peer address to connect with. Benefit here is that it means a) minimial config changes and b) is backwards compatible with old brokers. Only thing we'll need to keep in mind is that folks will have to use _our_ key generation comments -- `wg genkey` / `wg pubkey` won't work for multiple brokers.

Tl;dr:
1. Update `genkey` command to generate multiple keys concatenated together (default 3)
2. Update `pubkey` command to properly handle multiple private keys concatenated together
3. Update inbound proxy to select appropriate private key and local address depending on broker index value

There are some companion changes that need to be done in the broker gateway, but as long as nobody is using the broker index setting yet, everything should work.