### PR TITLE
optionally parse broker index from hostname

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,5 +96,5 @@ func init() {
 	rootCmd.PersistentFlags().StringArrayVarP(&configFiles, "config", "c", nil, "config file(s)")
 	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", false, "JSON log output")
 	rootCmd.PersistentFlags().IntVarP(&deploymentId, "deployment-id", "d", 0, "Semgrep deployment ID")
-	rootCmd.PersistentFlags().IntVarP(&brokerIndex, "broker-index", "i", 0, "Semgrep network broker index")
+	rootCmd.PersistentFlags().IntVarP(&brokerIndex, "broker-index", "i", -1, "Semgrep network broker index override (-1 to disable)")
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -73,15 +73,17 @@ type WireguardPeer struct {
 }
 
 type WireguardBase struct {
-	resolvedLocalAddress netip.Addr
-	LocalAddress         string                `mapstructure:"localAddress" json:"localAddress" validate:"format=ip"`
-	Dns                  []string              `mapstructure:"dns" json:"dns" validate:"empty=true > format=ip"`
-	Mtu                  int                   `mapstructure:"mtu" json:"mtu" validate:"gte=0" default:"1420"`
-	PrivateKey           SensitiveBase64String `mapstructure:"privateKey" json:"privateKey" validate:"empty=false"`
-	ListenPort           int                   `mapstructure:"listenPort" json:"listenPort" validate:"gte=0"`
-	Peers                []WireguardPeer       `mapstructure:"peers" json:"peers" validate:"empty=false"`
-	Verbose              bool                  `mapstructure:"verbose" json:"verbose"`
-	BrokerIndex          int                   `mapstructure:"brokerIndex" json:"brokerIndex" validate:"gte=0"`
+	resolvedLocalAddress     netip.Addr
+	resolvedBrokerIndex      int
+	LocalAddress             string                `mapstructure:"localAddress" json:"localAddress" validate:"format=ip"`
+	Dns                      []string              `mapstructure:"dns" json:"dns" validate:"empty=true > format=ip"`
+	Mtu                      int                   `mapstructure:"mtu" json:"mtu" validate:"gte=0" default:"1420"`
+	PrivateKey               SensitiveBase64String `mapstructure:"privateKey" json:"privateKey" validate:"empty=false"`
+	ListenPort               int                   `mapstructure:"listenPort" json:"listenPort" validate:"gte=0"`
+	Peers                    []WireguardPeer       `mapstructure:"peers" json:"peers" validate:"empty=false"`
+	Verbose                  bool                  `mapstructure:"verbose" json:"verbose"`
+	BrokerIndex              int                   `mapstructure:"brokerIndex" json:"brokerIndex" validate:"gte=0"`
+	BrokerIndexHostnameRegex string                `mapstructure:"brokerIndexHostnameRegex" json:"brokerIndexHostnameRegex"`
 }
 
 type BitTester interface {

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -75,6 +75,7 @@ type WireguardPeer struct {
 type WireguardBase struct {
 	resolvedLocalAddress     netip.Addr
 	resolvedBrokerIndex      int
+	brokerIndexOverride      int
 	LocalAddress             string                `mapstructure:"localAddress" json:"localAddress" validate:"format=ip"`
 	Dns                      []string              `mapstructure:"dns" json:"dns" validate:"empty=true > format=ip"`
 	Mtu                      int                   `mapstructure:"mtu" json:"mtu" validate:"gte=0" default:"1420"`
@@ -83,7 +84,7 @@ type WireguardBase struct {
 	Peers                    []WireguardPeer       `mapstructure:"peers" json:"peers" validate:"empty=false"`
 	Verbose                  bool                  `mapstructure:"verbose" json:"verbose"`
 	BrokerIndex              int                   `mapstructure:"brokerIndex" json:"brokerIndex" validate:"gte=0"`
-	BrokerIndexHostnameRegex string                `mapstructure:"brokerIndexHostnameRegex" json:"brokerIndexHostnameRegex"`
+	BrokerIndexHostnameRegex string                `mapstructure:"brokerIndexHostnameRegex" json:"brokerIndexHostnameRegex" default:"^.+-([0-9]+)$"`
 }
 
 type BitTester interface {
@@ -267,10 +268,10 @@ type Config struct {
 	Outbound OutboundProxyConfig `mapstructure:"outbound" json:"outbound"`
 }
 
-func LoadConfig(configFiles []string, deploymentId int, brokerIndex int) (*Config, error) {
+func LoadConfig(configFiles []string, deploymentId int, brokerIndexOverride int) (*Config, error) {
 	config := new(Config)
 
-	config.Inbound.Wireguard.BrokerIndex = brokerIndex
+	config.Inbound.Wireguard.brokerIndexOverride = brokerIndexOverride
 
 	if deploymentId > 0 {
 		hostname := os.Getenv("SEMGREP_HOSTNAME")


### PR DESCRIPTION
We should encourage folks to run multiple brokers in a StatefulSet, if they're running in Kubernetes. This PR adds an optional config field to parse the broker index from the hostname so that users don't have to deal with manually setting indexes.

Logic: (trying to find the right balance of explicit vs. "just works")
1. if `inbound.wireguard.brokerIndexHostnameRegex` is set, compile the regex (fail fast if invalid)
3. if `--broker-index` command line arg is set and >= 0, just use and ignore the other config settings
4. if `inbound.wireguard.brokerIndexHostnameRegex` is set, attempt to match against the hostname.
  a. Fail fast if we get an anomalous result (e.g. regex is missing a capture group or we fail to convert the capture group to an integer)
  b. Fall through if there's simply no regex match (i.e. we shouldn't panic if the broker is not deployed as a StatefulSet)
5. use whatever the `inbound.wireguard.brokerIndex` config value is (default `0`)


(default value of `inbound.wireguard.brokerIndexHostnameRegex` is `^.+-([0-9]+)$` which should work for stateful sets.