### PR TITLE
Revert "better support for running multiple separate brokers"

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -13,7 +13,7 @@ var dumpCmd = &cobra.Command{
 	Use:   "dump",
 	Short: "Dump current config",
 	Run: func(cmd *cobra.Command, args []string) {
-		config, err := pkg.LoadConfig(configFiles, deploymentId, brokerIndex)
+		config, err := pkg.LoadConfig(configFiles, deploymentId)
 		if err != nil {
 			log.Panic(err)
 		}

--- a/cmd/genkey.go
+++ b/cmd/genkey.go
@@ -3,43 +3,25 @@ package cmd
 import (
 	"encoding/base64"
 	"fmt"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
-var replicaCount int
-
-const defaultReplicaCount = 3
-const minReplicaCount = 1
-const maxReplicaCount = 16
-
 var genkeyCmd = &cobra.Command{
 	Use:   "genkey",
-	Short: "Generates a random Semgrep Network Broker private key and prints it to stdout.",
+	Short: "Generates a random private key in base64 and prints it to stdout",
 	Run: func(cmd *cobra.Command, args []string) {
-		if replicaCount < minReplicaCount || replicaCount > maxReplicaCount {
-			log.Panic(fmt.Errorf("replica count must be between %v and %v", minReplicaCount, maxReplicaCount))
+		privateKey, err := wgtypes.GeneratePrivateKey()
+		if err != nil {
+			log.Panic(fmt.Errorf("failed to generate private key: %v", err))
 		}
 
-		encoder := base64.NewEncoder(base64.StdEncoding, os.Stdout)
-		defer encoder.Close()
-
-		for i := 0; i < replicaCount; i++ {
-			privateKey, err := wgtypes.GeneratePrivateKey()
-			if err != nil {
-				log.Panic(fmt.Errorf("failed to generate private key %v: %v", i, err))
-			}
-			if _, err := encoder.Write(privateKey[:]); err != nil {
-				log.Panic(fmt.Errorf("failed to write private key %v: %v", i, err))
-			}
-		}
+		fmt.Println(base64.StdEncoding.EncodeToString(privateKey[:]))
 	},
 }
 
 func init() {
-	genkeyCmd.PersistentFlags().IntVarP(&replicaCount, "replica-count", "r", defaultReplicaCount, "Number of broker replicas to support")
 	rootCmd.AddCommand(genkeyCmd)
 }

--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -30,7 +30,7 @@ var relayCmd = &cobra.Command{
 		}()
 
 		// load config(s)
-		config, err := pkg.LoadConfig(configFiles, 0, 0)
+		config, err := pkg.LoadConfig(configFiles, 0)
 		if err != nil {
 			log.Panic(err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,6 @@ import (
 var configFiles []string
 var jsonLog bool
 var deploymentId int
-var brokerIndex int
 
 var rootCmd = &cobra.Command{
 	Use:     "semgrep-network-broker",
@@ -40,7 +39,7 @@ var rootCmd = &cobra.Command{
 		}()
 
 		// load config(s)
-		config, err := pkg.LoadConfig(configFiles, deploymentId, brokerIndex)
+		config, err := pkg.LoadConfig(configFiles, deploymentId)
 		if err != nil {
 			log.Panic(err)
 		}
@@ -76,7 +75,7 @@ func StartNetworkBroker(config *pkg.Config) (func() error, error) {
 		return wireguardTeardown()
 	}
 
-	// start inbound proxy (semgrep --> customer)
+	// start inbound proxy (r2c --> customer)
 	if err := config.Inbound.Start(tnet); err != nil {
 		teardown()
 		return nil, fmt.Errorf("failed to start inbound proxy: %v", err)
@@ -96,5 +95,4 @@ func init() {
 	rootCmd.PersistentFlags().StringArrayVarP(&configFiles, "config", "c", nil, "config file(s)")
 	rootCmd.PersistentFlags().BoolVarP(&jsonLog, "json-log", "j", false, "JSON log output")
 	rootCmd.PersistentFlags().IntVarP(&deploymentId, "deployment-id", "d", 0, "Semgrep deployment ID")
-	rootCmd.PersistentFlags().IntVarP(&brokerIndex, "broker-index", "i", 0, "Semgrep network broker index")
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/netip"
 	"net/url"
 	"os"
 	"reflect"
@@ -73,15 +72,13 @@ type WireguardPeer struct {
 }
 
 type WireguardBase struct {
-	resolvedLocalAddress netip.Addr
-	LocalAddress         string                `mapstructure:"localAddress" json:"localAddress" validate:"format=ip"`
-	Dns                  []string              `mapstructure:"dns" json:"dns" validate:"empty=true > format=ip"`
-	Mtu                  int                   `mapstructure:"mtu" json:"mtu" validate:"gte=0" default:"1420"`
-	PrivateKey           SensitiveBase64String `mapstructure:"privateKey" json:"privateKey" validate:"empty=false"`
-	ListenPort           int                   `mapstructure:"listenPort" json:"listenPort" validate:"gte=0"`
-	Peers                []WireguardPeer       `mapstructure:"peers" json:"peers" validate:"empty=false"`
-	Verbose              bool                  `mapstructure:"verbose" json:"verbose"`
-	BrokerIndex          int                   `mapstructure:"brokerIndex" json:"brokerIndex" validate:"gte=0"`
+	LocalAddress string                `mapstructure:"localAddress" json:"localAddress" validate:"format=ip"`
+	Dns          []string              `mapstructure:"dns" json:"dns" validate:"empty=true > format=ip"`
+	Mtu          int                   `mapstructure:"mtu" json:"mtu" validate:"gte=0" default:"1420"`
+	PrivateKey   SensitiveBase64String `mapstructure:"privateKey" json:"privateKey" validate:"empty=false"`
+	ListenPort   int                   `mapstructure:"listenPort" json:"listenPort" validate:"gte=0"`
+	Peers        []WireguardPeer       `mapstructure:"peers" json:"peers" validate:"empty=false"`
+	Verbose      bool                  `mapstructure:"verbose" json:"verbose"`
 }
 
 type BitTester interface {
@@ -265,10 +262,8 @@ type Config struct {
 	Outbound OutboundProxyConfig `mapstructure:"outbound" json:"outbound"`
 }
 
-func LoadConfig(configFiles []string, deploymentId int, brokerIndex int) (*Config, error) {
+func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 	config := new(Config)
-
-	config.Inbound.Wireguard.BrokerIndex = brokerIndex
 
 	if deploymentId > 0 {
 		hostname := os.Getenv("SEMGREP_HOSTNAME")

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestEmptyConfigs(t *testing.T) {
-	config, err := LoadConfig(nil, 0, 0)
+	config, err := LoadConfig(nil, 0)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Reverts semgrep/semgrep-network-broker#85. The more I think about this approach, the less I like it. Let's remove it before people start depending on it.