### PR TITLE
resolve wireguard peer info from TXT record

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -380,6 +380,10 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 						}
 						peer.PublicKey = Base64String(decoded_value)
 					}
+				case "heartbeat":
+					if config.Inbound.Heartbeat.URL == "" {
+						config.Inbound.Heartbeat.URL = value
+					}
 				default:
 					logger.WithField("record_key", key).WithField("record_value", value).Warn("txt_lookup.unrecognized_key")
 				}

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -349,6 +349,10 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				endpoint = endpoint[0:i]
 			}
 
+			if net.ParseIP(endpoint) != nil {
+				continue // cant look up TXT record for IPs
+			}
+
 			logger := log.WithField("endpoint", endpoint)
 
 			records, err := net.LookupTXT(endpoint)

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -367,13 +367,17 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 			key, value := record[0:i], record[i+1:]
 			switch key {
 			case "wireguardAllowedIps":
-				peer.AllowedIps = value
-			case "wireguardPublicKey":
-				decoded_value, err := base64.StdEncoding.DecodeString(value)
-				if err != nil {
-					return nil, fmt.Errorf("failed to decode pubkey %v: %w", value, err)
+				if peer.AllowedIps == "" {
+					peer.AllowedIps = value
 				}
-				peer.PublicKey = Base64String(decoded_value)
+			case "wireguardPublicKey":
+				if peer.PublicKey == nil {
+					decoded_value, err := base64.StdEncoding.DecodeString(value)
+					if err != nil {
+						return nil, fmt.Errorf("failed to decode pubkey %v: %w", value, err)
+					}
+					peer.PublicKey = Base64String(decoded_value)
+				}
 			default:
 				logger.WithField("record_key", key).WithField("record_value", value).Warn("txt_lookup.unrecognized_key")
 			}

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -3,13 +3,17 @@ package pkg
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"reflect"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/mcuadros/go-defaults"
 	"github.com/mitchellh/mapstructure"
@@ -265,6 +269,7 @@ type Config struct {
 func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 	config := new(Config)
 
+	// Step 1: Apply config values encoded in broker token (if provided)
 	tokenString, err := LoadTokenFromEnv()
 	if err != nil {
 		return config, fmt.Errorf("failed to load token: %v", err)
@@ -280,6 +285,8 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 		config.Inbound.Wireguard.PrivateKey = token.WireguardCredential.PrivateKey
 	}
 
+	// Step 2: Apply config values from semgrep.dev/api/broker/{deployment_id}/default-config, if a deployment ID is provided
+	// NOTE: we will be phasing this out in favor of retrieving default configs from the broker gateway
 	if deploymentId > 0 {
 		hostname := os.Getenv("SEMGREP_HOSTNAME")
 		if hostname == "" {
@@ -318,6 +325,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 		}
 	}
 
+	// Step 3: Load config files passed via command line
 	for i := range configFiles {
 		viper.SetConfigFile(configFiles[i])
 		if err := viper.MergeInConfig(); err != nil {
@@ -329,6 +337,50 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 	}); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %v", err)
 	}
+
+	// Step 4: Resolve TXT record(s) of wireguard peers, fill in config values if not set in a config file
+	for i := range config.Inbound.Wireguard.Peers {
+		peer := &config.Inbound.Wireguard.Peers[i]
+
+		endpoint := peer.Endpoint
+		if i := strings.Index(endpoint, ":"); i >= 0 {
+			endpoint = endpoint[0:i]
+		}
+
+		logger := log.WithField("endpoint", endpoint)
+
+		records, err := net.LookupTXT(endpoint)
+		if err != nil {
+			var dnsError *net.DNSError
+			if errors.As(err, &dnsError) && dnsError.IsNotFound {
+				logger.WithError(dnsError).Warn("txt_lookup.failed")
+			} else {
+				return nil, fmt.Errorf("failed to lookup TXT records for %v: %w", endpoint, err)
+			}
+		}
+
+		for _, record := range records {
+			i := strings.Index(record, "=")
+			if i < 0 {
+				continue // skip any records that arent key=value formatted
+			}
+			key, value := record[0:i], record[i+1:]
+			switch key {
+			case "wireguardAllowedIps":
+				peer.AllowedIps = value
+			case "wireguardPublicKey":
+				decoded_value, err := base64.StdEncoding.DecodeString(value)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode pubkey %v: %w", value, err)
+				}
+				peer.PublicKey = Base64String(decoded_value)
+			default:
+				logger.WithField("record_key", key).WithField("record_value", value).Warn("txt_lookup.unrecognized_key")
+			}
+		}
+	}
+
+	// Step 5: Apply default values to any remaining unset config fields
 	defaults.SetDefaults(config)
 
 	if config.Inbound.GitHub != nil {


### PR DESCRIPTION
- Allows us to disseminate our wireguard public key and the gateway allowedIPs CIDR via DNS
- No records / malformed records just print a warning
- Config files have priority (i.e. TXT record won't override a config file setting)