### PR TITLE
Add fetch for installation repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Under the hood, this config adds these allowlist items:
 - GET `https://github.example.com/api/v3/repos/:owner/:repo/pulls`
 - GET `https://github.example.com/api/v3/orgs/:org/installation`
 - GET `https://github.example.com/api/v3/orgs/:org/repos`
+- GET `https://github.example.com/api/v3/installation/repositories`
 - GET `https://github.example.com/api/v3/users/:user/installation`
 - GET `https://github.example.com/api/v3/users/:user/installation/repositories`
 - GET `https://github.example.com/api/v3/app`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -452,6 +452,12 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
+			// alternative: check repos for an installation
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/installation/repositories").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
 			// check app installation for a personal account
 			AllowlistItem{
 				URL:               gitHubBaseUrl.JoinPath("/users/:user/installation").String(),


### PR DESCRIPTION
The current driver uses all three of the repo URL types: per org, per user, and per installation.