### PR TITLE
add ci jobs urls to the github configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Under the hood, this config adds these allowlist items:
 - GET `https://github.example.com/api/v3/app`
 - GET `https://github.example.com/api/v3/repos/:org/:repo/actions/secrets/public-key`
 - GET `https://github.example.com/api/v3/repos/:org/:repo/contents/.github/workflows/semgrep.yml`
+- PUT `https://github.example.com/api/v3/repos/:org/:repo/contents/.github/workflows/semgrep.yml`
 - PUT `https://github.example.com/api/v3/repos/:org/:repo/actions/secrets/:secret`
 - POST `https://github.example.com/api/v3/app/installations/:id/access_tokens`
 - POST `https://github.example.com/api/v3/app-manifests/:code/conversions`

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Under the hood, this config adds these allowlist items:
 - GET `https://github.example.com/api/v3/repos/:org/:repo/actions/secrets/public-key`
 - GET `https://github.example.com/api/v3/repos/:org/:repo/contents/.github/workflows/semgrep.yml`
 - PUT `https://github.example.com/api/v3/repos/:org/:repo/contents/.github/workflows/semgrep.yml`
-- PUT `https://github.example.com/api/v3/repos/:org/:repo/actions/secrets/:secret`
+- PUT `https://github.example.com/api/v3/repos/:org/:repo/actions/secrets/SEMGREP_APP_TOKEN`
 - POST `https://github.example.com/api/v3/app/installations/:id/access_tokens`
 - POST `https://github.example.com/api/v3/app-manifests/:code/conversions`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/pulls/:number/comments`

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Under the hood, this config adds these allowlist items:
 - GET `https://github.example.com/api/v3/users/:user/installation`
 - GET `https://github.example.com/api/v3/users/:user/installation/repositories`
 - GET `https://github.example.com/api/v3/app`
+- GET `https://github.example.com/api/v3/repos/:org/:repo/actions/secrets/public-key`
+- GET `https://github.example.com/api/v3/repos/:org/:repo/contents/.github/workflows/semgrep.yml`
+- PUT `https://github.example.com/api/v3/repos/:org/:repo/actions/secrets/:secret`
 - POST `https://github.example.com/api/v3/app/installations/:id/access_tokens`
 - POST `https://github.example.com/api/v3/app-manifests/:code/conversions`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/pulls/:number/comments`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -488,7 +488,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				SetRequestHeaders: headers,
 			},
 			AllowlistItem{
-				URL:               gitHubBaseUrl.JoinPath("/repos/:org/:repo/actions/secrets/:secret").String(),
+				URL:               gitHubBaseUrl.JoinPath("/repos/:org/:repo/actions/secrets/SEMGREP_APP_TOKEN").String(),
 				Methods:           ParseHttpMethods([]string{"PUT"}),
 				SetRequestHeaders: headers,
 			},

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -499,7 +499,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 			},
 			AllowlistItem{
 				URL:               gitHubBaseUrl.JoinPath("/repos/:org/:repo/contents/.github/workflows/semgrep.yml").String(),
-				Methods:           ParseHttpMethods([]string{"GET"}),
+				Methods:           ParseHttpMethods([]string{"GET", "PUT"}),
 				SetRequestHeaders: headers,
 			},
 		)

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -486,7 +486,23 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				URL:               gitHubBaseUrl.JoinPath("/app/installations/:id/access_tokens").String(),
 				Methods:           ParseHttpMethods([]string{"POST"}),
 				SetRequestHeaders: headers,
-			})
+			},
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/repos/:org/:repo/actions/secrets/:secret").String(),
+				Methods:           ParseHttpMethods([]string{"PUT"}),
+				SetRequestHeaders: headers,
+			},
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/repos/:org/:repo/actions/secrets/public-key").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/repos/:org/:repo/contents/.github/workflows/semgrep.yml").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
+		)
 
 		if config.Inbound.GitHub.AllowCodeAccess {
 			config.Inbound.Allowlist = append(config.Inbound.Allowlist,


### PR DESCRIPTION
Add more urls to the default GitHub allowlist. These urls are required if the customer wants to automatically create a CI job from the semgrep UI.