### PR TITLE
add endpoints for kubernetes probes

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -263,8 +263,9 @@ type OutboundProxyConfig struct {
 }
 
 type MetricsConfig struct {
-	Disabled bool   `mapstructure:"disabled" json:"disabled"`
-	Addr     string `mapstructure:"addr" json:"addr" default:":9000"`
+	Disabled                      bool   `mapstructure:"disabled" json:"disabled"`
+	Addr                          string `mapstructure:"addr" json:"addr" default:":9000"`
+	HealthcheckGracePeriodSeconds int    `mapstructure:"healthcheckGracePeriodSeconds" json:"healthcheckGracePeriodSeconds" validate:"gte=0" default:"10"`
 }
 
 type Config struct {

--- a/pkg/heartbeat.go
+++ b/pkg/heartbeat.go
@@ -9,6 +9,9 @@ import (
 	"golang.zx2c4.com/wireguard/tun/netstack"
 )
 
+var hasSeenSuccessfulHeartbeat bool
+var lastSuccessfulHeartbeat time.Time
+
 func (config *HeartbeatConfig) Start(tnet *netstack.Net, userAgent string) (func(), error) {
 	ticker := time.NewTicker(time.Duration(config.IntervalSeconds) * time.Second)
 	done := make(chan bool)
@@ -51,6 +54,8 @@ func (config *HeartbeatConfig) Start(tnet *netstack.Net, userAgent string) (func
 			failures = 0
 			heartbeatSuccessCounter.Inc()
 			heartbeatLastSuccessTimestamp.SetToCurrentTime()
+			hasSeenSuccessfulHeartbeat = true
+			lastSuccessfulHeartbeat = time.Now()
 			return true
 		}
 	}


### PR DESCRIPTION
- Serve metrics specifically on `/metrics` instead of on all URLs
- Add startup probe (`/probes/startup`), which returns HTTP 200 once the broker has had a successful heartbeat
- Add readiness probe ( `/probes/readiness`), which returns HTTP 200 as long as the broker has has a recent succesful heartbeat (grace period for late heartbeats defined in `metrics.healthcheckGracePeriodSeconds`)
  - Failing readiness probe == take remove pod from service, which doesn't really apply to the broker (it's not designed to be a target of a kubernetes service), but it's still a useful probe because it makes it easier for customers to understand when the broker is healthy


I chose not to implement a liveness probe because I'm not sure when we'd detect when the broker is wedged. We can implement this later if we have some good ideas