### PR TITLE
chore(gitlab): add missing API urls for Gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ inbound:
     - url: http://example.com/api/v3/repos/:owner/:repo/pulls/:number/comments
       methods: [GET]
       setRequestHeaders:
-        Authorization: 'Bearer ...snip...'
+        Authorization: "Bearer ...snip..."
 ```
 
 ### Real-world example
@@ -208,19 +208,19 @@ allowlist:
   - url: https://git.example.com/api/v3/repos/:owner/:repo
     methods: [GET]
     setRequestHeaders:
-      Authorization: 'Bearer <GH TOKEN>'
+      Authorization: "Bearer <GH TOKEN>"
   - url: https://git.example.com/api/v3/repos/:owner/:repo/pulls
     methods: [GET]
     setRequestHeaders:
-      Authorization: 'Bearer <GH TOKEN>'
+      Authorization: "Bearer <GH TOKEN>"
   - url: https://git.example.com/api/v3/repos/:owner/:repo/pulls/:number/comments
     methods: [POST]
     setRequestHeaders:
-      Authorization: 'Bearer <GH TOKEN>'
+      Authorization: "Bearer <GH TOKEN>"
   - url: https://git.example.com/api/v3/repos/:owner/:repo/issues/:number/comments
     methods: [POST]
     setRequestHeaders:
-      Authorization: 'Bearer <GH TOKEN>'
+      Authorization: "Bearer <GH TOKEN>"
 ```
 
 ### Logging
@@ -294,7 +294,7 @@ outbound:
   relay:
     test:
       destinationUrl: https://httpbin.org/anything
-      jsonPath: '$.foo'
+      jsonPath: "$.foo"
       equals:
         - bar
 ```
@@ -311,7 +311,7 @@ outbound:
   relay:
     test:
       destinationUrl: https://httpbin.org/anything
-      jsonPath: '$.foo'
+      jsonPath: "$.foo"
       equals:
         - bar
       additionalConfigs:

--- a/README.md
+++ b/README.md
@@ -133,12 +133,14 @@ Under the hood, this config adds these allowlist items:
 - GET `https://gitlab.example.com/api/v4/namespaces/:namespace`
 - GET `https://gitlab.example.com/api/v4/projects/:project`
 - GET `https://gitlab.example.com/api/v4/projects/:project/members/all/:user`
+- GET `https://gitlab.example.com/api/v4/groups/:namespace/members/all/:user`
 - GET `https://gitlab.example.com/api/v4/projects/:project/merge_requests`
 - GET `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/versions`
 - GET `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions`
 - GET `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions/:discussion/notes/:note/award_emoji`
 - GET `https://gitlab.example.com/api/v4/projects/:project/repository/branches`
 - GET `https://gitlab.example.com/api/v4/:entity_type/:namespace/projects`
+- PUT `https://gitlab.example.com/api/v4/groups/:namespace/hooks`
 - POST `https://gitlab.example.com/api/v4/groups/:namespace/hooks`
 - POST `https://gitlab.example.com/api/v4/projects/:project/hooks`
 - POST `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions`
@@ -152,6 +154,7 @@ And if `allowCodeAccess` is set, additionally:
 - GET `https://gitlab.example.com/api/v4/projects/:project/repository/commits`
 - GET `https://gitlab.example.com/api/v4/projects/:project/repository/compare`
 - POST `https://gitlab.example.com/api/v4/projects/:project/statuses/:commit`
+- GET `https://gitlab.example.com/api/v4/personal_access_tokens/self`
 
 ### Bitbucket
 
@@ -193,7 +196,7 @@ inbound:
     - url: http://example.com/api/v3/repos/:owner/:repo/pulls/:number/comments
       methods: [GET]
       setRequestHeaders:
-        Authorization: "Bearer ...snip..."
+        Authorization: 'Bearer ...snip...'
 ```
 
 ### Real-world example
@@ -205,19 +208,19 @@ allowlist:
   - url: https://git.example.com/api/v3/repos/:owner/:repo
     methods: [GET]
     setRequestHeaders:
-      Authorization: "Bearer <GH TOKEN>"
+      Authorization: 'Bearer <GH TOKEN>'
   - url: https://git.example.com/api/v3/repos/:owner/:repo/pulls
     methods: [GET]
     setRequestHeaders:
-      Authorization: "Bearer <GH TOKEN>"
+      Authorization: 'Bearer <GH TOKEN>'
   - url: https://git.example.com/api/v3/repos/:owner/:repo/pulls/:number/comments
     methods: [POST]
     setRequestHeaders:
-      Authorization: "Bearer <GH TOKEN>"
+      Authorization: 'Bearer <GH TOKEN>'
   - url: https://git.example.com/api/v3/repos/:owner/:repo/issues/:number/comments
     methods: [POST]
     setRequestHeaders:
-      Authorization: "Bearer <GH TOKEN>"
+      Authorization: 'Bearer <GH TOKEN>'
 ```
 
 ### Logging
@@ -291,7 +294,7 @@ outbound:
   relay:
     test:
       destinationUrl: https://httpbin.org/anything
-      jsonPath: "$.foo"
+      jsonPath: '$.foo'
       equals:
         - bar
 ```
@@ -308,7 +311,7 @@ outbound:
   relay:
     test:
       destinationUrl: https://httpbin.org/anything
-      jsonPath: "$.foo"
+      jsonPath: '$.foo'
       equals:
         - bar
       additionalConfigs:

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -521,7 +521,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 			// Group webhooks
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/groups/:namespace/hooks").String(),
-				Methods:           ParseHttpMethods([]string{"GET", "POST"}),
+				Methods:           ParseHttpMethods([]string{"GET", "POST", "PUT"}),
 				SetRequestHeaders: headers,
 			},
 			AllowlistItem{
@@ -531,7 +531,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 			},
 			// Group info
 			AllowlistItem{
-				URL:               gitLabBaseUrl.JoinPath("/namespaces/:namespace").String(),
+				URL:               gitLabBaseUrl.JoinPath("/groups/:namespace").String(),
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
@@ -550,6 +550,12 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/projects/:project/hooks/:hook").String(),
 				Methods:           ParseHttpMethods([]string{"DELETE"}),
+				SetRequestHeaders: headers,
+			},
+			// Get a group member
+			AllowlistItem{
+				URL:               gitLabBaseUrl.JoinPath("/groups/:namespace/members/all/:user").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
 			// Get a repo member
@@ -609,6 +615,12 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 			// Get reactions to comments
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/projects/:project/merge_requests/:number/discussions/:discussion/notes/:note/award_emoji").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
+			// Get scm token info
+			AllowlistItem{
+				URL:               gitLabBaseUrl.JoinPath("/personal_access_tokens/self").String(),
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},


### PR DESCRIPTION
We have been adding new features that use Gitlab APIs that are not on the allowlist yet:
- update namespace webhook
- get a namespace member
- get scm token info