### PR TITLE
chore(ado): add an allowlist for azure devops

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,40 @@ Under the hood, this config adds these allowlist items:
 - POST `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/pull-requests/:number/comments`
 - POST `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/pull-requests/:number/blocker-comments`
 
+### AzureDevops
+
+Similarly, the `azuredevops` configuration section grants Semgrep access to azure devops.
+
+```yaml
+inbound:
+  bitbucket:
+    baseUrl: https://example@dev.azure.com/
+    token: ...
+    allowCodeAccess: false # default is false, set to true to allow Semgrep to read file contents
+```
+
+Under the hood, this config adds these allowlist items:
+
+- GET `https://example@dev.azure.com/:namespace/_apis/connectionData`
+- GET `https://example@dev.azure.com/:namespace/_apis/projects/:project`
+- GET `https://example@dev.azure.com/:namespace/:project/_apis/git/repositories`
+- GET `https://example@dev.azure.com/:namespace/:project/_apis/git/repositories/:repo`
+- GET `https://example@dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests`
+- GET `https://example@dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests/:number/iterations`
+- POST `https://example@dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests/:number/threads`
+- PATCH `https://example@dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests/:number/threads`
+- POST `https://example@dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests/:number/threads/:threadId/comments`
+- PATCH `https://example@dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests/:number/threads/:threadId/comments/:commentId`
+- GET `https://example@dev.azure.com/:namespace/:project/_apis/hooks/subscriptions`
+- POST `https://example@dev.azure.com/:namespace/:project/_apis/hooks/subscriptions`
+- PUT `https://example@dev.azure.com/:namespace/:project/_apis/hooks/subscriptions`
+- GET `https://example@vsaex.dev.azure.com/:namespace/_apis/groupentitlements`
+
+And if `allowCodeAccess` is set, additionally:
+
+- GET `https://example@dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/items`
+- POST `https://example@dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/commits/:commit/statuses`
+
 ### Allowlist
 
 The `allowlist` configuration section provides finer-grained control over what HTTP requests are allowed to be forwarded out of the broker. The first matching allowlist item is used. No allowlist match means the request will not be proxied.

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -827,7 +827,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 			AllowlistItem{
 				URL:               azureDevOpsBaseUrl.JoinPath("/:namespace/:project/_apis/hooks/subscriptions").String(),
 				Methods:           ParseHttpMethods([]string{"GET", "POST", "PUT"}),
-				SetRequestHeaders: headers,	
+				SetRequestHeaders: headers,
 			},
 			// list teams
 			AllowlistItem{
@@ -839,7 +839,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 
 		if config.Inbound.AzureDevOps.AllowCodeAccess {
 			config.Inbound.Allowlist = append(config.Inbound.Allowlist,
-				// get file content 
+				// get file content
 				AllowlistItem{
 					URL:               azureDevOpsBaseUrl.JoinPath("/:namespace/:project/_apis/git/repositories/:repo/items").String(),
 					Methods:           ParseHttpMethods([]string{"GET"}),
@@ -847,7 +847,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				},
 				// update commit status
 				AllowlistItem{
-					URL:               azureDevOpsBaseUrl.JoinPath("/:namespace/:project/_apis/git/repositories/:repo/commits/:commit/statuses").String(),	
+					URL:               azureDevOpsBaseUrl.JoinPath("/:namespace/:project/_apis/git/repositories/:repo/commits/:commit/statuses").String(),
 					Methods:           ParseHttpMethods([]string{"POST"}),
 					SetRequestHeaders: headers,
 				},

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -225,9 +225,9 @@ type BitBucket struct {
 }
 
 type AzureDevOps struct {
-	BaseURL string `mapstructure:"baseUrl" json:"baseUrl"`
-	Token   string `mapstructure:"token" json:"token"`
-	AllowCodeAccess bool `mapstructure:"allowCodeAccess" json:"allowCodeAccess"`
+	BaseURL         string `mapstructure:"baseUrl" json:"baseUrl"`
+	Token           string `mapstructure:"token" json:"token"`
+	AllowCodeAccess bool   `mapstructure:"allowCodeAccess" json:"allowCodeAccess"`
 }
 
 type HttpClientConfig struct {
@@ -741,7 +741,6 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				Methods:           ParseHttpMethods([]string{"POST"}),
 				SetRequestHeaders: headers,
 			},
-
 		)
 	}
 
@@ -758,7 +757,6 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse azure devops vsaex base URL: %v", err)
 		}
-
 
 		var headers map[string]string
 		if azureDevOps.Token != "" {
@@ -831,8 +829,8 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 			},
 			// list teams
 			AllowlistItem{
-				URL:  		   vsaexUrl.JoinPath("/:namespace/_apis/groupentitlements").String(),
-				Methods:       ParseHttpMethods([]string{"GET"}),
+				URL:               vsaexUrl.JoinPath("/:namespace/_apis/groupentitlements").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
 		)


### PR DESCRIPTION
As we are officially adding Azure DevOps support, we are expecting customers to configure it using network broker, so we need to provide a dedicated configuration in network broker to ensure controlled access to Azure DevOps endpoints. 
