### PR TITLE
chore(bitbucket): update bitbucket network config

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ inbound:
   bitbucket:
     baseUrl: https://bitbucket.example.com/rest/api/latest
     token: ...
+    allowCodeAccess: false # default is false, set to true to allow Semgrep to read file contents
 ```
 
 Under the hood, this config adds these allowlist items:
@@ -177,7 +178,19 @@ Under the hood, this config adds these allowlist items:
 - GET `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/default-branch`
 - GET `https://bitbucket.example.com/rest/api/latest/projects/:project/:repo/pull-requests`
 - POST `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/pull-requests/:number/comments`
+- GET `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/pull-requests/:number/comments/:comment`
+- PUT `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/pull-requests/:number/comments/:comment`
 - POST `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/pull-requests/:number/blocker-comments`
+- GET `https://bitbucket.example.com/rest/api/latest/projects/:project/webhooks`
+- POST `https://bitbucket.example.com/rest/api/latest/projects/:project/webhooks`
+- PUT `https://bitbucket.example.com/rest/api/latest/projects/:project/webhooks/:webhook`
+- DELETE `https://bitbucket.example.com/rest/api/latest/projects/:project/webhooks/:webhook`
+
+And if `allowCodeAccess` is set, additionally:
+
+- GET `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/browse/:filepath`
+- POST `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/commit/:commit/builds`
+
 
 ### Allowlist
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -220,8 +220,9 @@ type GitLab struct {
 }
 
 type BitBucket struct {
-	BaseURL string `mapstructure:"baseUrl" json:"baseUrl"`
-	Token   string `mapstructure:"token" json:"token"`
+	BaseURL         string `mapstructure:"baseUrl" json:"baseUrl"`
+	Token           string `mapstructure:"token" json:"token"`
+	AllowCodeAccess bool   `mapstructure:"allowCodeAccess" json:"allowCodeAccess"`
 }
 
 type HttpClientConfig struct {
@@ -728,13 +729,48 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				Methods:           ParseHttpMethods([]string{"POST"}),
 				SetRequestHeaders: headers,
 			},
+			// get and update PR comment
+			AllowlistItem{
+				URL:               bitBucketBaseUrl.JoinPath("/projects/:project/repos/:repo/pull-requests/:number/comments/:comment").String(),
+				Methods:           ParseHttpMethods([]string{"GET", "PUT"}),
+				SetRequestHeaders: headers,
+			},
 			// post blockerPR comment
 			AllowlistItem{
 				URL:               bitBucketBaseUrl.JoinPath("/projects/:project/repos/:repo/pull-requests/:number/blocker-comments").String(),
 				Methods:           ParseHttpMethods([]string{"POST"}),
 				SetRequestHeaders: headers,
 			},
+			// namespace webhooks
+			AllowlistItem{
+				URL:               bitBucketBaseUrl.JoinPath("/projects/:project/webhooks").String(),
+				Methods:           ParseHttpMethods([]string{"GET", "POST"}),
+				SetRequestHeaders: headers,
+			},
+			AllowlistItem{
+				URL:               bitBucketBaseUrl.JoinPath("/projects/:project/webhooks/:webhook").String(),
+				Methods:           ParseHttpMethods([]string{"PUT", "DELETE"}),
+				SetRequestHeaders: headers,
+			},
 		)
+
+		if config.Inbound.BitBucket.AllowCodeAccess {
+			// get contents of file
+			config.Inbound.Allowlist = append(config.Inbound.Allowlist,
+				AllowlistItem{
+					URL:               bitBucketBaseUrl.JoinPath("/projects/:project/repos/:repo/browse/:filepath").String(),
+					Methods:           ParseHttpMethods([]string{"GET"}),
+					SetRequestHeaders: headers,
+				},
+				// update commit status
+				AllowlistItem{
+					URL:               bitBucketBaseUrl.JoinPath("/projects/:project/repos/:repo/commit/:commit/builds").String(),
+					Methods:           ParseHttpMethods([]string{"POST"}),
+					SetRequestHeaders: headers,
+				},
+			)
+
+		}
 	}
 
 	return config, nil


### PR DESCRIPTION
We have been adding new features that use bitbucket APIs that are not on the allowlist yet:

- get, create, update and delete namespace webhook
- get and update pull request comment
- get file content
- update commit status