### PR TITLE
chore: Add graphql to the config for Github 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ Under the hood, this config adds these allowlist items:
 - POST `https://github.example.com/api/v3/app-manifests/:code/conversions`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/pulls/:number/comments`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/issues/:number/comments`
+- POST `https://github.example.com/graphql`
+  - GraphQL Operations:
+    - Query
+      - GetBlameDetails
+    - Mutations
+      - resolveReviewThread
+      - unresolveReviewThread
 
 And if `allowCodeAccess` is set, additionally:
 
@@ -193,7 +200,6 @@ And if `allowCodeAccess` is set, additionally:
 
 - GET `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/browse/:filepath`
 - POST `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/commit/:commit/builds`
-
 
 ### AzureDevops
 

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/graphql-go/graphql v0.8.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/graphql-go/graphql v0.8.1 h1:p7/Ou/WpmulocJeEx7wjQy611rtXGQaAcXGqanuMMgc=
+github.com/graphql-go/graphql v0.8.1/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -247,7 +247,7 @@ func (config *InboundProxyConfig) validateGitHubGraphQLRequest(body []byte, filt
 }
 
 type GitHubGraphQLFilter struct {
-	AllowedOperations map[string][]string `validate:"omitempty"` // map[operationType][]operationName
+	AllowedOperations map[string][]string `validate:"required"` // map[operationType][]operationName
 }
 type AllowlistItem struct {
 	URL                   string               `mapstructure:"url" json:"url"`
@@ -258,7 +258,7 @@ type AllowlistItem struct {
 	LogRequestHeaders     bool                 `mapstructure:"logRequestHeaders" json:"logRequestHeaders"`
 	LogResponseBody       bool                 `mapstructure:"logResponseBody" json:"logResponseBody"`
 	LogResponseHeaders    bool                 `mapstructure:"logResponseHeaders" json:"logResponseHeaders"`
-	GitHubGraphQL         *GitHubGraphQLFilter `validate:"omitempty"`
+	GitHubGraphQL         *GitHubGraphQLFilter `mapstructure:"githubGraphQL" json:"githubGraphQL"`
 }
 
 type Allowlist []AllowlistItem

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -180,18 +180,18 @@ func httpMethodsDecodeHook(f reflect.Type, t reflect.Type, data interface{}) (in
 	return ParseHttpMethods(methods), nil
 }
 
-type githubGraphQLRequest struct {
+type graphQlRequest struct {
 	Query         string                 `json:"query"`
 	OperationName string                 `json:"operationName,omitempty"`
 	Variables     map[string]interface{} `json:"variables,omitempty"`
 }
 
-func (config *InboundProxyConfig) validateGitHubGraphQLRequest(body []byte, filter *GitHubGraphQLFilter) error {
+func (config *InboundProxyConfig) validateGraphQLRequest(body []byte, filter *GraphQLFilter) error {
 	if filter == nil {
 		return nil
 	}
 
-	var req githubGraphQLRequest
+	var req graphQlRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		return fmt.Errorf("invalid GitHub GraphQL request JSON: %v", err)
 	}
@@ -246,19 +246,19 @@ func (config *InboundProxyConfig) validateGitHubGraphQLRequest(body []byte, filt
 	return fmt.Errorf("GitHub GraphQL %s operation '%s' not allowed", opType, opName)
 }
 
-type GitHubGraphQLFilter struct {
+type GraphQLFilter struct {
 	AllowedOperations map[string][]string `validate:"required"` // map[operationType][]operationName
 }
 type AllowlistItem struct {
-	URL                   string               `mapstructure:"url" json:"url"`
-	Methods               HttpMethods          `mapstructure:"methods" json:"methods"`
-	SetRequestHeaders     map[string]string    `mapstructure:"setRequestHeaders" json:"setRequestHeaders"`
-	RemoveResponseHeaders []string             `mapstructure:"removeResponseHeaders" json:"removeRequestHeaders"`
-	LogRequestBody        bool                 `mapstructure:"logRequestBody" json:"logRequestBody"`
-	LogRequestHeaders     bool                 `mapstructure:"logRequestHeaders" json:"logRequestHeaders"`
-	LogResponseBody       bool                 `mapstructure:"logResponseBody" json:"logResponseBody"`
-	LogResponseHeaders    bool                 `mapstructure:"logResponseHeaders" json:"logResponseHeaders"`
-	GitHubGraphQL         *GitHubGraphQLFilter `mapstructure:"githubGraphQL" json:"githubGraphQL"`
+	URL                   string            `mapstructure:"url" json:"url"`
+	Methods               HttpMethods       `mapstructure:"methods" json:"methods"`
+	SetRequestHeaders     map[string]string `mapstructure:"setRequestHeaders" json:"setRequestHeaders"`
+	RemoveResponseHeaders []string          `mapstructure:"removeResponseHeaders" json:"removeRequestHeaders"`
+	LogRequestBody        bool              `mapstructure:"logRequestBody" json:"logRequestBody"`
+	LogRequestHeaders     bool              `mapstructure:"logRequestHeaders" json:"logRequestHeaders"`
+	LogResponseBody       bool              `mapstructure:"logResponseBody" json:"logResponseBody"`
+	LogResponseHeaders    bool              `mapstructure:"logResponseHeaders" json:"logResponseHeaders"`
+	GraphQLData           *GraphQLFilter    `mapstructure:"githubGraphQL" json:"githubGraphQL"`
 }
 
 type Allowlist []AllowlistItem
@@ -594,7 +594,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				URL:               gitHubBaseUrl.JoinPath("/graphql").String(),
 				Methods:           ParseHttpMethods([]string{"POST"}),
 				SetRequestHeaders: headers,
-				GitHubGraphQL: &GitHubGraphQLFilter{
+				GraphQLData: &GraphQLFilter{
 					AllowedOperations: map[string][]string{
 						"query": {
 							"GetBlameDetails",

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -492,6 +492,10 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse github base URL: %v", err)
 		}
+		gitHubBaseUrlGraphQL, err := url.Parse(strings.Replace(gitHub.BaseURL, "/api/v3", "/api/graphql", 1))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse github GraphQL base URL: %v", err)
+		}
 
 		var headers map[string]string
 		if gitHub.Token != "" {
@@ -591,7 +595,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 			},
 			// Graphql API with specific operations
 			AllowlistItem{
-				URL:               gitHubBaseUrl.JoinPath("/graphql").String(),
+				URL:               gitHubBaseUrlGraphQL.String(),
 				Methods:           ParseHttpMethods([]string{"POST"}),
 				SetRequestHeaders: headers,
 				GraphQLData: &GraphQLFilter{

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -517,6 +517,11 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				Methods:           ParseHttpMethods([]string{"GET", "PUT"}),
 				SetRequestHeaders: headers,
 			},
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/graphql").String(),
+				Methods:           ParseHttpMethods([]string{"POST"}),
+				SetRequestHeaders: headers,
+			},
 		)
 
 		if config.Inbound.GitHub.AllowCodeAccess {

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -156,9 +156,9 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		{
 			name: "valid query operation",
 			request: githubGraphQLRequest{
-				Query: `query GetRepository { 
-                    repository(owner: "owner", name: "name") { 
-                        id 
+				Query: `query GetRepository {
+                    repository(owner: "owner", name: "name") {
+                        id
                     }
                 }`,
 				OperationName: "GetRepository",
@@ -168,9 +168,9 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		{
 			name: "valid query operation no operation name",
 			request: githubGraphQLRequest{
-				Query: `query GetRepository { 
-                    repository(owner: "owner", name: "name") { 
-                        id 
+				Query: `query GetRepository {
+                    repository(owner: "owner", name: "name") {
+                        id
                     }
                 }`,
 			},
@@ -179,9 +179,9 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		{
 			name: "valid mutation operation",
 			request: githubGraphQLRequest{
-				Query: `mutation CreateIssue { 
-                    createIssue(input: {repositoryId: "123", title: "title"}) { 
-                        issue { id } 
+				Query: `mutation CreateIssue {
+                    createIssue(input: {repositoryId: "123", title: "title"}) {
+                        issue { id }
                     }
                 }`,
 				OperationName: "CreateIssue",
@@ -191,9 +191,9 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		{
 			name: "operation not in allowlist",
 			request: githubGraphQLRequest{
-				Query: `query GetUser { 
-                    user(login: "username") { 
-                        id 
+				Query: `query GetUser {
+                    user(login: "username") {
+                        id
                     }
                 }`,
 				OperationName: "GetUser",
@@ -204,9 +204,9 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		{
 			name: "operation type not allowed",
 			request: githubGraphQLRequest{
-				Query: `subscription WatchRepository { 
-                    repository { 
-                        id 
+				Query: `subscription WatchRepository {
+                    repository {
+                        id
                     }
                 }`,
 				OperationName: "WatchRepository",
@@ -217,9 +217,9 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		{
 			name: "unnamed operation",
 			request: githubGraphQLRequest{
-				Query: `query { 
-                    repository(owner: "owner", name: "name") { 
-                        id 
+				Query: `query {
+                    repository(owner: "owner", name: "name") {
+                        id
                     }
                 }`,
 			},
@@ -229,9 +229,9 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		{
 			name: "operation name mismatch",
 			request: githubGraphQLRequest{
-				Query: `query GetRepository { 
-                    repository(owner: "owner", name: "name") { 
-                        id 
+				Query: `query GetRepository {
+                    repository(owner: "owner", name: "name") {
+                        id
                     }
                 }`,
 				OperationName: "DifferentName",
@@ -242,9 +242,9 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		{
 			name: "invalid GraphQL syntax",
 			request: githubGraphQLRequest{
-				Query: `query GetRepository { 
-                    repository(owner: "owner", name: "name") { 
-                        id 
+				Query: `query GetRepository {
+                    repository(owner: "owner", name: "name") {
+                        id
                     `, // Missing closing brace
 				OperationName: "GetRepository",
 			},
@@ -280,9 +280,9 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 func TestGitHubGraphQLValidationWithNilFilter(t *testing.T) {
 	config := &InboundProxyConfig{}
 	request := githubGraphQLRequest{
-		Query: `query GetRepository { 
-            repository(owner: "owner", name: "name") { 
-                id 
+		Query: `query GetRepository {
+            repository(owner: "owner", name: "name") {
+                id
             }
         }`,
 		OperationName: "GetRepository",

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -138,9 +138,9 @@ func TestHttpMethodsDecodeHook(t *testing.T) {
 	}
 }
 
-func TestGitHubGraphQLValidation(t *testing.T) {
+func TestGraphQLValidation(t *testing.T) {
 	config := &InboundProxyConfig{}
-	filter := &GitHubGraphQLFilter{
+	filter := &GraphQLFilter{
 		AllowedOperations: map[string][]string{
 			"query":    {"GetRepository", "GetPullRequest"},
 			"mutation": {"CreateIssue"},
@@ -149,13 +149,13 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		request     githubGraphQLRequest
+		request     graphQlRequest
 		shouldError bool
 		errorMsg    string
 	}{
 		{
 			name: "valid query operation",
-			request: githubGraphQLRequest{
+			request: graphQlRequest{
 				Query: `query GetRepository {
                     repository(owner: "owner", name: "name") {
                         id
@@ -167,7 +167,7 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		},
 		{
 			name: "valid query operation no operation name",
-			request: githubGraphQLRequest{
+			request: graphQlRequest{
 				Query: `query GetRepository {
                     repository(owner: "owner", name: "name") {
                         id
@@ -178,7 +178,7 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		},
 		{
 			name: "valid mutation operation",
-			request: githubGraphQLRequest{
+			request: graphQlRequest{
 				Query: `mutation CreateIssue {
                     createIssue(input: {repositoryId: "123", title: "title"}) {
                         issue { id }
@@ -190,7 +190,7 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		},
 		{
 			name: "operation not in allowlist",
-			request: githubGraphQLRequest{
+			request: graphQlRequest{
 				Query: `query GetUser {
                     user(login: "username") {
                         id
@@ -203,7 +203,7 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		},
 		{
 			name: "operation type not allowed",
-			request: githubGraphQLRequest{
+			request: graphQlRequest{
 				Query: `subscription WatchRepository {
                     repository {
                         id
@@ -216,7 +216,7 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		},
 		{
 			name: "unnamed operation",
-			request: githubGraphQLRequest{
+			request: graphQlRequest{
 				Query: `query {
                     repository(owner: "owner", name: "name") {
                         id
@@ -228,7 +228,7 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		},
 		{
 			name: "operation name mismatch",
-			request: githubGraphQLRequest{
+			request: graphQlRequest{
 				Query: `query GetRepository {
                     repository(owner: "owner", name: "name") {
                         id
@@ -241,7 +241,7 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 		},
 		{
 			name: "invalid GraphQL syntax",
-			request: githubGraphQLRequest{
+			request: graphQlRequest{
 				Query: `query GetRepository {
                     repository(owner: "owner", name: "name") {
                         id
@@ -260,7 +260,7 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 				t.Fatalf("failed to marshal request: %v", err)
 			}
 
-			err = config.validateGitHubGraphQLRequest(requestBody, filter)
+			err = config.validateGraphQLRequest(requestBody, filter)
 
 			if tt.shouldError {
 				if err == nil {
@@ -277,9 +277,9 @@ func TestGitHubGraphQLValidation(t *testing.T) {
 	}
 }
 
-func TestGitHubGraphQLValidationWithNilFilter(t *testing.T) {
+func TestGraphQLValidationWithNilFilter(t *testing.T) {
 	config := &InboundProxyConfig{}
-	request := githubGraphQLRequest{
+	request := graphQlRequest{
 		Query: `query GetRepository {
             repository(owner: "owner", name: "name") {
                 id
@@ -293,7 +293,7 @@ func TestGitHubGraphQLValidationWithNilFilter(t *testing.T) {
 		t.Fatalf("failed to marshal request: %v", err)
 	}
 
-	err = config.validateGitHubGraphQLRequest(requestBody, nil)
+	err = config.validateGraphQLRequest(requestBody, nil)
 	if err != nil {
 		t.Errorf("expected no error with nil filter but got: %v", err)
 	}

--- a/pkg/inbound_proxy.go
+++ b/pkg/inbound_proxy.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -81,9 +80,8 @@ func (config *InboundProxyConfig) Start(tnet *netstack.Net) error {
 		}
 
 		// Just to make sure validate all three of these things before checking
-		if allowlistMatch.GitHubGraphQL != nil &&
-			c.Request.Method == "POST" &&
-			strings.HasSuffix(destinationUrl.Path, "/graphql") {
+		if allowlistMatch.GraphQLData != nil &&
+			c.Request.Method == "POST" {
 
 			bodyBytes, err := io.ReadAll(c.Request.Body)
 			if err != nil {
@@ -95,7 +93,7 @@ func (config *InboundProxyConfig) Start(tnet *netstack.Net) error {
 			// Restore the body for later use
 			c.Request.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
-			if err := config.validateGitHubGraphQLRequest(bodyBytes, allowlistMatch.GitHubGraphQL); err != nil {
+			if err := config.validateGraphQLRequest(bodyBytes, allowlistMatch.GraphQLData); err != nil {
 				logger.WithError(err).Warn("github_graphql.validation_error")
 				c.Header(errorResponseHeader, "1")
 				c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})

--- a/pkg/inbound_proxy.go
+++ b/pkg/inbound_proxy.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -77,6 +78,29 @@ func (config *InboundProxyConfig) Start(tnet *netstack.Net) error {
 			c.Header(errorResponseHeader, "1")
 			c.JSON(http.StatusForbidden, gin.H{"error": "url is not in allowlist"})
 			return
+		}
+
+		// Just to make sure validate all three of these things before checking
+		if allowlistMatch.GitHubGraphQL != nil &&
+			c.Request.Method == "POST" &&
+			strings.HasSuffix(destinationUrl.Path, "/graphql") {
+
+			bodyBytes, err := io.ReadAll(c.Request.Body)
+			if err != nil {
+				logger.WithError(err).Warn("github_graphql.read_body_error")
+				c.Header(errorResponseHeader, "1")
+				c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read request body"})
+				return
+			}
+			// Restore the body for later use
+			c.Request.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+			if err := config.validateGitHubGraphQLRequest(bodyBytes, allowlistMatch.GitHubGraphQL); err != nil {
+				logger.WithError(err).Warn("github_graphql.validation_error")
+				c.Header(errorResponseHeader, "1")
+				c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+				return
+			}
 		}
 
 		logger = logger.WithField("allowlist_match", allowlistMatch.URL)


### PR DESCRIPTION
We want to start using graphql exclusive Github api features. This will add support for the graphql endpoint at 

https://api.github.com/graphql

https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#the-graphql-endpoint

uses: 
https://github.com/semgrep/semgrep-app/pull/17492
