### PR TITLE
fix: code access allowlist items need to use a wildcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Under the hood, this config adds these allowlist items:
 
 And if `allowCodeAccess` is set, additionally:
 
-- GET `https://github.example.com/api/v3/repos/:repo/contents/:filepath`
+- GET `https://github.example.com/api/v3/repos/:repo/contents/*`
 - GET `https://github.example.com/api/v3/repos/:repo/commits`
 
 ### GitLab
@@ -155,7 +155,7 @@ Under the hood, this config adds these allowlist items:
 
 And if `allowCodeAccess` is set, additionally:
 
-- GET `https://gitlab.example.com/api/v4/projects/:project/repository/files/:filepath`
+- GET `https://gitlab.example.com/api/v4/projects/:project/repository/files/*`
 - GET `https://gitlab.example.com/api/v4/projects/:project/repository/commits`
 - GET `https://gitlab.example.com/api/v4/projects/:project/repository/compare`
 - POST `https://gitlab.example.com/api/v4/projects/:project/statuses/:commit`
@@ -191,7 +191,7 @@ Under the hood, this config adds these allowlist items:
 
 And if `allowCodeAccess` is set, additionally:
 
-- GET `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/browse/:filepath`
+- GET `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/browse/*`
 - POST `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/commit/:commit/builds`
 
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -523,7 +523,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 			config.Inbound.Allowlist = append(config.Inbound.Allowlist,
 				// get contents of file
 				AllowlistItem{
-					URL:               gitHubBaseUrl.JoinPath("/repos/:repo/contents/:filepath").String(),
+					URL:               gitHubBaseUrl.JoinPath("/repos/:repo/contents/*").String(),
 					Methods:           ParseHttpMethods([]string{"GET"}),
 					SetRequestHeaders: headers,
 				},
@@ -667,7 +667,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 			config.Inbound.Allowlist = append(config.Inbound.Allowlist,
 				// get contents of file
 				AllowlistItem{
-					URL:               gitLabBaseUrl.JoinPath("/projects/:project/repository/files/:filepath").String(),
+					URL:               gitLabBaseUrl.JoinPath("/projects/:project/repository/files/*").String(),
 					Methods:           ParseHttpMethods([]string{"GET"}),
 					SetRequestHeaders: headers,
 				},
@@ -777,7 +777,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 			// get contents of file
 			config.Inbound.Allowlist = append(config.Inbound.Allowlist,
 				AllowlistItem{
-					URL:               bitBucketBaseUrl.JoinPath("/projects/:project/repos/:repo/browse/:filepath").String(),
+					URL:               bitBucketBaseUrl.JoinPath("/projects/:project/repos/:repo/browse/*").String(),
 					Methods:           ParseHttpMethods([]string{"GET"}),
 					SetRequestHeaders: headers,
 				},


### PR DESCRIPTION
re: https://github.com/semgrep/semgrep-network-broker/pull/80/files#diff-26f0185e462eee9c623c61960b8c34d80b910e4bc4984842100f38dd1965462cR402, `:filepath` only matches up to the first slash, we need to be using a wildcard (`*`) to correctly match file paths