### PR TITLE
default config to well known wireguard peer

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -22,6 +22,7 @@ import (
 
 const SemgrepHostnameEnvVar = "SEMGREP_HOSTNAME"
 const DefaultSemgrepHostname = "semgrep.dev"
+const SemgrepWireguardPeerFormat = "wireguard.%s:51820"
 
 func getSemgrepHostname() string {
 	hostname := os.Getenv(SemgrepHostnameEnvVar)
@@ -301,7 +302,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 	// Step 0: Set default wireguard peer
 	config.Inbound.Wireguard.Peers = []WireguardPeer{
 		{
-			Endpoint: fmt.Sprintf("wireguard.%s:51820", hostname),
+			Endpoint: fmt.Sprintf(SemgrepWireguardPeerFormat, hostname),
 		},
 	}
 


### PR DESCRIPTION
The wireguard peer list is pretty baked at this point, so let's set a good default (`wireguard.semgrep.dev:51820`) so that there's fewer things for customers to copypasta around. This should be a no-op for all existing users since lists are overwritten at config merge time.