### PR TITLE
Restore /namespaces/:namespace allowlist

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -589,12 +589,6 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
-			// Group info
-			AllowlistItem{
-				URL:               gitLabBaseUrl.JoinPath("/groups/:namespace").String(),
-				Methods:           ParseHttpMethods([]string{"GET"}),
-				SetRequestHeaders: headers,
-			},
 			// repo info
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/projects/:project").String(),

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -583,6 +583,12 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				Methods:           ParseHttpMethods([]string{"DELETE"}),
 				SetRequestHeaders: headers,
 			},
+			// Namespace info
+			AllowlistItem{
+				URL:               gitLabBaseUrl.JoinPath("/namespaces/:namespace").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
 			// Group info
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/groups/:namespace").String(),


### PR DESCRIPTION
The SCM driver uses both /namespaces/ and /groups/ in different places as they're slightly different things (namespaces is the more general term).

This URL is still listed in the README so it doesn't also need to be restored there.