### PR TITLE
add support for encoded allowlist urls

### DIFF
--- a/pkg/allowlist.go
+++ b/pkg/allowlist.go
@@ -12,13 +12,16 @@ func (config AllowlistItem) Matches(method string, url *url.URL) bool {
 		return false
 	}
 
-	parsedUrl, _ := url.Parse(config.URL)
+	parsedUrl, err := url.Parse(config.URL)
+	if err != nil {
+		return false
+	}
 
 	if parsedUrl.Scheme != url.Scheme || parsedUrl.Host != url.Host {
 		return false
 	}
 
-	matcher := urlpath.New(parsedUrl.Path)
+	matcher := urlpath.New(parsedUrl.EscapedPath())
 	if _, matches := matcher.Match(url.EscapedPath()); matches {
 		return true
 	}

--- a/pkg/allowlist_test.go
+++ b/pkg/allowlist_test.go
@@ -139,17 +139,3 @@ func TestAllowlistEncodedPathMatch(t *testing.T) {
 	assertAllowlistMatch(t, allowlist, "GET", "https://gitlab.example.com/api/v4/projects/test-group%2Ftest-project/repository/files/path/to/file", true)
 	assertAllowlistMatch(t, allowlist, "GET", "https://gitlab.example.com/api/v4/projects/test-group/test-project/repository/files/path/to/file", false)
 }
-
-func TestAllowlistIPv6Match(t *testing.T) {
-	allowlist := &Allowlist{
-		AllowlistItem{
-			URL:     "http://[fdf0:59dc:33cf:9be9:0000:0000:0000:0001]/ping",
-			Methods: ParseHttpMethods([]string{"GET"}),
-		},
-	}
-
-	// Test IPv6 address matching
-	assertAllowlistMatch(t, allowlist, "GET", "http://[fdf0:59dc:33cf:9be9:0000:0000:0000:0001]/ping", true)
-	assertAllowlistMatch(t, allowlist, "GET", "http://[fdf0:59dc:33cf:9be9::1]/ping", false)                  // Different format of same address
-	assertAllowlistMatch(t, allowlist, "GET", "http://[fdf0:59dc:33cf:9be9:0000:0000:0000:0002]/ping", false) // Different address
-}

--- a/pkg/allowlist_test.go
+++ b/pkg/allowlist_test.go
@@ -118,3 +118,38 @@ func TestAllowlistPathMatch(t *testing.T) {
 	assertAllowlistMatch(t, allowlist, "GET", "https://foo.com/variable-path/bla%2Fbla/suffix", true)
 	assertAllowlistMatch(t, allowlist, "GET", "https://foo.com/variable-path/bla/bla/suffix", false)
 }
+
+func TestAllowlistEncodedPathMatch(t *testing.T) {
+	allowlist := &Allowlist{
+		AllowlistItem{
+			URL:     "https://gitlab.example.com/api/v4/projects/group%2Fproject/repository/files/*",
+			Methods: ParseHttpMethods([]string{"GET"}),
+		},
+		AllowlistItem{
+			URL:     "https://gitlab.example.com/api/v4/projects/:group%2F:project/repository/files/*",
+			Methods: ParseHttpMethods([]string{"GET"}),
+		},
+	}
+
+	// Test that encoded forward slashes in the path match correctly
+	assertAllowlistMatch(t, allowlist, "GET", "https://gitlab.example.com/api/v4/projects/group%2Fproject/repository/files/path/to/file", true)
+	assertAllowlistMatch(t, allowlist, "GET", "https://gitlab.example.com/api/v4/projects/group/project/repository/files/path/to/file", false)
+
+	// Test with variables containing encoded characters
+	assertAllowlistMatch(t, allowlist, "GET", "https://gitlab.example.com/api/v4/projects/test-group%2Ftest-project/repository/files/path/to/file", true)
+	assertAllowlistMatch(t, allowlist, "GET", "https://gitlab.example.com/api/v4/projects/test-group/test-project/repository/files/path/to/file", false)
+}
+
+func TestAllowlistIPv6Match(t *testing.T) {
+	allowlist := &Allowlist{
+		AllowlistItem{
+			URL:     "http://[fdf0:59dc:33cf:9be9:0000:0000:0000:0001]/ping",
+			Methods: ParseHttpMethods([]string{"GET"}),
+		},
+	}
+
+	// Test IPv6 address matching
+	assertAllowlistMatch(t, allowlist, "GET", "http://[fdf0:59dc:33cf:9be9:0000:0000:0000:0001]/ping", true)
+	assertAllowlistMatch(t, allowlist, "GET", "http://[fdf0:59dc:33cf:9be9::1]/ping", false)                  // Different format of same address
+	assertAllowlistMatch(t, allowlist, "GET", "http://[fdf0:59dc:33cf:9be9:0000:0000:0000:0002]/ping", false) // Different address
+}


### PR DESCRIPTION
We have a customer who is unwilling to allow code access to all of their GitLab projects; therefore, they maintain a unique allowlist to ungate specific projects. Consequently, they are using encoded characters (`%2F`) in the allowlist items because that is how GitLab handles the `groups/namespace` part of the URL. This was incompatible with the existing logic, as we were not using `escapedPath()` while initializing a matcher. A test has also been added for this case.
