### PR TITLE
fix: Support Bitbucket Datacenter code access url

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -806,7 +806,7 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 				},
 				// checkout repo
 				AllowlistItem{
-					URL:               bitBucketBaseUrl.JoinPath("/scm/:project/:repo.git/*").String(),
+					URL:               bitBucketBaseUrl.JoinPath("/scm/:project/:repo/*").String(),
 					Methods:           ParseHttpMethods([]string{"GET"}),
 					SetRequestHeaders: headers,
 				},

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -804,8 +804,13 @@ func LoadConfig(configFiles []string, deploymentId int) (*Config, error) {
 					Methods:           ParseHttpMethods([]string{"POST"}),
 					SetRequestHeaders: headers,
 				},
+				// checkout repo
+				AllowlistItem{
+					URL:               bitBucketBaseUrl.JoinPath("/scm/:project/:repo.git/*").String(),
+					Methods:           ParseHttpMethods([]string{"GET"}),
+					SetRequestHeaders: headers,
+				},
 			)
-
 		}
 	}
 


### PR DESCRIPTION
Bitbucket Datacenter uses a specific URL for repo cloning which is not currently included in the `allowCodeAccess` allowlist.