### PR TITLE
chore(allowlist): add GET repo collaborator permission API to the allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Under the hood, this config adds these allowlist items:
 - GET `https://github.example.com/orgs/:org/teams`
 - GET `https://github.example.com/orgs/:org/teams/:team_slug/members`
 - GET `https://github.example.com/repos/:org/:repo/actions/secrets/public-key`
+- GET `https://github.example.com/repos/:org/:repo/collaborators/:username/permission`
 - GET `https://github.example.com/repos/:org/:repo/compare/:basehead`
 - GET `https://github.example.com/repos/:org/:repo/contents/.github/workflows/semgrep.yml`
 - GET `https://github.example.com/repos/:org/:repo/installation`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -636,6 +636,11 @@ func PopulateAllowLists(config *Config) error {
 				Methods:           ParseHttpMethods([]string{"POST"}),
 				SetRequestHeaders: headers,
 			},
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/repos/:org/:repo/collaborators/:username/permission").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
 		)
 
 		if config.Inbound.GitHub.AllowCodeAccess {


### PR DESCRIPTION
We added using Github's [GET repo collaborator permission API](https://docs.github.com/en/rest/collaborators/collaborators?apiVersion=2022-11-28#get-repository-permissions-for-a-user) when processing PR comment webhook events. This is for updating the allowlist to include this API.