### PR TITLE
chore(allowlist): add Azure Devops GET iteration changes API to the allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Under the hood, this config adds these allowlist items:
 - GET `https://dev.azure.com/:namespace/:project/_apis/git/repositories/:repo`
 - GET `https://dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests`
 - GET `https://dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests/:number/iterations`
+- GET `https://dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests/:number/iterations/:iterationId/changes`
 - GET `https://dev.azure.com/:namespace/:project/_apis/hooks/subscriptions`
 - GET `https://dev.azure.com/:namespace/_apis/connectionData`
 - GET `https://dev.azure.com/:namespace/_apis/projects/:project`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -998,6 +998,12 @@ func PopulateAllowLists(config *Config) error {
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
+			// get pull request iteration changes
+			AllowlistItem{
+				URL:               azureDevOpsBaseUrl.JoinPath("/:namespace/:project/_apis/git/repositories/:repo/pullRequests/:number/iterations/:iterationId/changes").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
 			// post and update PR comment
 			AllowlistItem{
 				URL:               azureDevOpsBaseUrl.JoinPath("/:namespace/:project/_apis/git/repositories/:repo/pullRequests/:number/threads").String(),


### PR DESCRIPTION
We recently started using Azure Devops [GET pull request iteration changes API](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-iteration-changes/get?view=azure-devops-rest-7.1&tabs=HTTP) to find file's change tracking id. This PR is to add this API to the allow list.