### PR TITLE
fix(gha): Upgrade ubuntu version used in semgrep scan workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   semgrep:
     name: semgrep/ci
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:


### PR DESCRIPTION
semgrep scan workflow is using ubuntu-20.04 which has reached EOL. Upgrading to 22.04.