### PR TITLE
Add optional tlsMinVersion parameter to httpClient configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ inbound:
   httpClient:
     additionalCACerts:
       - /path/to/custom/cert.pem
-    tlsMinVersion: "1.2" # Optional. Valid values: "1.2", "1.3". Defaults to "1.3" if unset or invalid.
+    tlsMinVersion: "1.2" # Optional. Valid values: "1.2", "1.3". Defaults to "1.3" if unset.
 ```
 
 ### GitHub

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ inbound:
   httpClient:
     additionalCACerts:
       - /path/to/custom/cert.pem
+    minVersion: "1.2" # Optional. Valid values: "1.2", "1.3". Defaults to "1.3" if unset or invalid.
 ```
 
 ### GitHub

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ inbound:
   httpClient:
     additionalCACerts:
       - /path/to/custom/cert.pem
-    minVersion: "1.2" # Optional. Valid values: "1.2", "1.3". Defaults to "1.3" if unset or invalid.
+    tlsMinVersion: "1.2" # Optional. Valid values: "1.2", "1.3". Defaults to "1.3" if unset or invalid.
 ```
 
 ### GitHub

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -245,7 +245,7 @@ type AzureDevOps struct {
 
 type HttpClientConfig struct {
 	AdditionalCACerts []string `mapstructure:"additionalCACerts" json:"additionalCACerts"`
-	TlsMinVersion     string   `mapstructure:"tlsMinVersion" json:"tlsMinVersion"` // Valid values: "1.2", "1.3". Optional. Defaults to "1.3" if unset or invalid.
+	TlsMinVersion     string   `mapstructure:"tlsMinVersion" json:"tlsMinVersion" validate:"one_of=1.2,1.3" default:"1.3"`
 }
 
 type InboundProxyConfig struct {

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -245,7 +245,7 @@ type AzureDevOps struct {
 
 type HttpClientConfig struct {
 	AdditionalCACerts []string `mapstructure:"additionalCACerts" json:"additionalCACerts"`
-	MinVersion        string   `mapstructure:"minVersion" json:"minVersion"` // Valid values: "1.2", "1.3". Optional. Defaults to "1.3" if unset or invalid.
+	TlsMinVersion     string   `mapstructure:"tlsMinVersion" json:"tlsMinVersion"` // Valid values: "1.2", "1.3". Optional. Defaults to "1.3" if unset or invalid.
 }
 
 type InboundProxyConfig struct {

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -245,6 +245,7 @@ type AzureDevOps struct {
 
 type HttpClientConfig struct {
 	AdditionalCACerts []string `mapstructure:"additionalCACerts" json:"additionalCACerts"`
+	MinVersion        string   `mapstructure:"minVersion" json:"minVersion"` // Valid values: "1.2", "1.3". Optional. Defaults to "1.3" if unset or invalid.
 }
 
 type InboundProxyConfig struct {

--- a/pkg/http_client.go
+++ b/pkg/http_client.go
@@ -26,6 +26,8 @@ func (hcc *HttpClientConfig) BuildRoundTripper() (http.RoundTripper, error) {
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 
+	var certPool *x509.CertPool // nil certPool == use default system certs
+
 	if len(hcc.AdditionalCACerts) > 0 {
 		certPool, err := x509.SystemCertPool()
 		if err != nil {
@@ -42,21 +44,21 @@ func (hcc *HttpClientConfig) BuildRoundTripper() (http.RoundTripper, error) {
 				return nil, fmt.Errorf("failed to add CA cert to pool: %v", hcc.AdditionalCACerts[i])
 			}
 		}
-		minVersion := uint16(tls.VersionTLS13)
-		switch hcc.TlsMinVersion {
-		case "1.2":
-			minVersion = uint16(tls.VersionTLS12)
-		case "1.3":
-			minVersion = uint16(tls.VersionTLS13)
-		default:
-			if hcc.TlsMinVersion != "" {
-				return nil, fmt.Errorf("invalid tlsMinVersion: %q. tlsMinVersion must be '1.2' or '1.3' — older TLS versions are not supported", hcc.TlsMinVersion)
-			}
-		}
-		transport.TLSClientConfig = &tls.Config{
-			RootCAs:    certPool,
-			MinVersion: minVersion,
-		}
+	}
+
+	var minVersion uint16
+	switch hcc.TlsMinVersion {
+	case "1.2":
+		minVersion = uint16(tls.VersionTLS12)
+	case "1.3":
+	case "":
+		minVersion = uint16(tls.VersionTLS13)
+	default:
+		return nil, fmt.Errorf("invalid tlsMinVersion: %q. tlsMinVersion must be '1.2' or '1.3' — older TLS versions are not supported", hcc.TlsMinVersion)
+	}
+	transport.TLSClientConfig = &tls.Config{
+		RootCAs:    certPool,
+		MinVersion: minVersion,
 	}
 
 	return transport, nil

--- a/pkg/http_client.go
+++ b/pkg/http_client.go
@@ -48,6 +48,10 @@ func (hcc *HttpClientConfig) BuildRoundTripper() (http.RoundTripper, error) {
 			minVersion = uint16(tls.VersionTLS12)
 		case "1.3":
 			minVersion = uint16(tls.VersionTLS13)
+		default:
+			if hcc.TlsMinVersion != "" {
+				return nil, fmt.Errorf("invalid tlsMinVersion: %q. tlsMinVersion must be '1.2' or '1.3' — older TLS versions are not supported", hcc.TlsMinVersion)
+			}
 		}
 		transport.TLSClientConfig = &tls.Config{
 			ClientCAs:  certPool,

--- a/pkg/http_client.go
+++ b/pkg/http_client.go
@@ -42,9 +42,16 @@ func (hcc *HttpClientConfig) BuildRoundTripper() (http.RoundTripper, error) {
 				return nil, fmt.Errorf("failed to add CA cert to pool: %v", hcc.AdditionalCACerts[i])
 			}
 		}
+		minVersion := tls.VersionTLS13
+		switch hcc.MinVersion {
+		case "1.2":
+			minVersion = tls.VersionTLS12
+		case "1.3":
+			minVersion = tls.VersionTLS13
+		}
 		transport.TLSClientConfig = &tls.Config{
 			ClientCAs:  certPool,
-			MinVersion: tls.VersionTLS13,
+			MinVersion: minVersion,
 		}
 	}
 

--- a/pkg/http_client.go
+++ b/pkg/http_client.go
@@ -43,7 +43,7 @@ func (hcc *HttpClientConfig) BuildRoundTripper() (http.RoundTripper, error) {
 			}
 		}
 		minVersion := tls.VersionTLS13
-		switch hcc.MinVersion {
+		switch hcc.TlsMinVersion {
 		case "1.2":
 			minVersion = tls.VersionTLS12
 		case "1.3":

--- a/pkg/http_client.go
+++ b/pkg/http_client.go
@@ -42,12 +42,12 @@ func (hcc *HttpClientConfig) BuildRoundTripper() (http.RoundTripper, error) {
 				return nil, fmt.Errorf("failed to add CA cert to pool: %v", hcc.AdditionalCACerts[i])
 			}
 		}
-		minVersion := tls.VersionTLS13
+		minVersion := uint16(tls.VersionTLS13)
 		switch hcc.TlsMinVersion {
 		case "1.2":
-			minVersion = tls.VersionTLS12
+			minVersion = uint16(tls.VersionTLS12)
 		case "1.3":
-			minVersion = tls.VersionTLS13
+			minVersion = uint16(tls.VersionTLS13)
 		}
 		transport.TLSClientConfig = &tls.Config{
 			ClientCAs:  certPool,


### PR DESCRIPTION
This change adds the optional ability to add a `tlsMinVersion` dict to `httpClient:` and configure TLS to allow for v1.2.

This allows for the flexibility to support SCMs that dont yet provide TLSv1.3.

TLS versions below 1.2 are not supported intentionally as they're known to be insecure.
