### PR TITLE
Append provided CA Certs to the RootCA pool, not ClientCA

### DIFF
--- a/pkg/http_client.go
+++ b/pkg/http_client.go
@@ -43,7 +43,7 @@ func (hcc *HttpClientConfig) BuildRoundTripper() (http.RoundTripper, error) {
 			}
 		}
 		transport.TLSClientConfig = &tls.Config{
-			ClientCAs:  certPool,
+			RootCAs:    certPool,
 			MinVersion: tls.VersionTLS13,
 		}
 	}


### PR DESCRIPTION
In [Go's tls.Config](https://pkg.go.dev/crypto/tls#Config), `ClientCAs` are used to validate the **client's** certificate in **mTLS** connections. What we _actually_ want to allow configuration of for the network broker, are `RootCAs`, so that `semgrep-network-broker`'s httpClient can validate self-signed **server** certificates.

This explains why some users of the network broker with self-signed certs for their SCMs have reported success using the `$SSL_CERT_DIR` environment variable, which effectively does the same thing for Go's tls configuration (all PEM-encoded cert files in the SSL_CERT_DER are appended to the root trust).