### PR TITLE
Refine sample kubernetes manifest file for simplicity and ease of use

### DIFF
--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -8,10 +8,9 @@ data:
     # This minimal example shows how to configure an optional allowlist and a GitHub Enterprise Server
     inbound:
       allowlist: [] # Optional. Empty list means all traffic outbound from the broker is permitted
-    github:
-      baseURL: https://GITHUB_BASE_URL/api/v3
-      token: GITHUB_PAT
-      allowCodeAccess: true
+      github:
+        baseURL: https://GITHUB_BASE_URL/api/v3
+        allowCodeAccess: true
 
 ---
 apiVersion: apps/v1
@@ -37,7 +36,7 @@ spec:
         - -c
         - /conf/config.yaml
         - -c
-        - /private/private-key.yaml
+        - /secret/broker-secret.yaml
         - --deployment-id
         - "YOUR_ORGANIZATION_ID" # UPDATE with your organization ID from https://semgrep.dev/orgs/-/settings/general/identifiers
         resources:
@@ -51,24 +50,26 @@ spec:
         - mountPath: /conf
           name: config-volume
           readOnly: true
-        - mountPath: /private
-          name: private-key-volume
+        - mountPath: /secret
+          name: broker-secret-volume
           readOnly: true
       volumes:
       - name: config-volume
         configMap:
           name: broker-config
-      - name: private-key-volume
+      - name: broker-secret-volume
         secret:
-          secretName: broker-private-key
+          secretName: broker-secret
 
 # ---
-# To create the kubernetes secret for the WireGuard private key, generate a file named private-key.yaml with the following contents:
+# To create the kubernetes secret for the WireGuard private key and GitHub PAT, generate a file named broker-secret.yaml with the following contents:
 #
 #   inbound:
 #     wireguard:
 #       privateKey: WIREGUARD-PRIVATE-KEY-HERE
+#   github:
+#     token: GITHUB-PAT-HERE
 #
 # Then create the Kubernetes secret with:
 #
-#   kubectl create secret generic broker-private-key-yaml --from-file=private-key.yaml
+#   kubectl create secret generic broker-secret --from-file=broker-secret.yaml

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -5,11 +5,14 @@ metadata:
 data:
   config.yaml: |
     # Review https://semgrep.dev/docs/semgrep-ci/network-broker for more instructions
-    # *NOTE*: This is a minimal example. You must update the deployment-id value and create a secret for the private key.
+    # This minimal example shows how to configure an optional allowlist and a GitHub Enterprise Server
     inbound:
-      wireguard:
-        peers:
-        - endpoint: wireguard.semgrep.dev:51820
+      allowlist: [] # Optional. Empty list means all traffic outbound from the broker is permitted
+    github:
+      baseURL: https://GITHUB_BASE_URL/api/v3
+      token: GITHUB_PAT
+      allowCodeAccess: true
+
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -4,21 +4,12 @@ metadata:
   name: broker-config
 data:
   config.yaml: |
-    # note: all of these values are bogus; the broker will start up but not actually work
+    # Review https://semgrep.dev/docs/semgrep-ci/network-broker for more instructions
+    # *NOTE*: This is a minimal example. You must update the deployment-id value and create a secret for the private key.
     inbound:
       wireguard:
-        localAddress: 192.168.0.2
-        privateKey: 8DzUuki1Qn+Fdoc8IuRfhCfEL6/OMAIknx45QGtJFVs=
         peers:
-        - publicKey: OgJxJJvNIFZb5UO15VACP9IlVnhkURq+v7PV80c0IB0=
-          endpoint: example.com:51820
-          allowedIps: 192.168.0.1/32
-      heartbeat:
-        url: http://192.168.0.1/ping
-      allowlist:
-        - url: http://example.com/*
-          methods:
-          - GET
+        - endpoint: wireguard.semgrep.dev:51820
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -37,11 +28,15 @@ spec:
         app: semgrep-network-broker
     spec:
       containers:
-      - name: gateway
-        image: image-goes-here
+      - name: broker
+        image: ghcr.io/semgrep/semgrep-network-broker:v0.34.0
         args:
         - -c
         - /conf/config.yaml
+        - -c
+        - /private/private-key.yaml
+        - --deployment-id
+        - "YOUR_ORGANIZATION_ID" # UPDATE with your organization ID from https://semgrep.dev/orgs/-/settings/general/identifiers
         resources:
           limits:
             cpu: "1"
@@ -53,7 +48,24 @@ spec:
         - mountPath: /conf
           name: config-volume
           readOnly: true
+        - mountPath: /private
+          name: private-key-volume
+          readOnly: true
       volumes:
       - name: config-volume
         configMap:
           name: broker-config
+      - name: private-key-volume
+        secret:
+          secretName: broker-private-key
+
+# ---
+# To create the kubernetes secret for the WireGuard private key, generate a file named private-key.yaml with the following contents:
+#
+#   inbound:
+#     wireguard:
+#       privateKey: WIREGUARD-PRIVATE-KEY-HERE
+#
+# Then create the Kubernetes secret with:
+#
+#   kubectl create secret generic broker-private-key-yaml --from-file=private-key.yaml

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -10,7 +10,6 @@ data:
       allowlist: [] # Optional. Empty list means all traffic outbound from the broker is permitted
       github:
         baseURL: https://GITHUB_BASE_URL/api/v3
-        allowCodeAccess: true
 
 ---
 apiVersion: apps/v1
@@ -31,7 +30,7 @@ spec:
     spec:
       containers:
       - name: broker
-        image: ghcr.io/semgrep/semgrep-network-broker:v0.34.0
+        image: ghcr.io/semgrep/semgrep-network-broker:v0.34.0 # Update to desired tag version from https://github.com/semgrep/semgrep-network-broker/tags
         args:
         - -c
         - /conf/config.yaml
@@ -62,14 +61,13 @@ spec:
           secretName: broker-secret
 
 # ---
-# To create the kubernetes secret for the WireGuard private key and GitHub PAT, generate a file named broker-secret.yaml with the following contents:
+# To create the kubernetes secret for the WireGuard private key, generate a file named broker-secret.yaml with the following contents:
 #
 #   inbound:
 #     wireguard:
 #       privateKey: WIREGUARD-PRIVATE-KEY-HERE
-#   github:
-#     token: GITHUB-PAT-HERE
 #
 # Then create the Kubernetes secret with:
 #
 #   kubectl create secret generic broker-secret --from-file=broker-secret.yaml
+# ---

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -4,12 +4,12 @@ metadata:
   name: broker-config
 data:
   config.yaml: |
-    # Review https://semgrep.dev/docs/semgrep-ci/network-broker for more instructions
-    # This minimal example shows how to configure an optional allowlist and a GitHub Enterprise Server
+    # Review https://semgrep.dev/docs/semgrep-ci/network-broker for more instructions.
+    # This minimal example shows how to configure an optional allowlist and a GitHub Enterprise Server.
     inbound:
-      allowlist: [] # Optional. Empty list means all traffic outbound from the broker is permitted
+      allowlist: [] # Optional. If unset, defaults to an empty array, permitting all outbound traffic from broker.
       github:
-        baseURL: https://GITHUB_BASE_URL/api/v3
+        baseURL: https://GHES_HOSTNAME/api/v3 # Update GHES_HOSTNAME to the domain of your GitHub server.
 
 ---
 apiVersion: apps/v1
@@ -30,14 +30,15 @@ spec:
     spec:
       containers:
       - name: broker
-        image: ghcr.io/semgrep/semgrep-network-broker:v0.34.0 # Update to desired tag version from https://github.com/semgrep/semgrep-network-broker/tags
+        # Optionally replace :latest with desired tag version from https://github.com/semgrep/semgrep-network-broker/tags
+        image: ghcr.io/semgrep/semgrep-network-broker:latest 
         args:
         - -c
         - /conf/config.yaml
         - -c
         - /secret/broker-secret.yaml
         - --deployment-id
-        - "YOUR_ORGANIZATION_ID" # UPDATE with your organization ID from https://semgrep.dev/orgs/-/settings/general/identifiers
+        - "YOUR_ORGANIZATION_ID" # Update with your organization ID from https://semgrep.dev/orgs/-/settings/general/identifiers
         resources:
           limits:
             cpu: "1"

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
       - name: broker
         # Optionally replace :latest with desired tag version from https://github.com/semgrep/semgrep-network-broker/tags
-        image: ghcr.io/semgrep/semgrep-network-broker:latest 
+        image: ghcr.io/semgrep/semgrep-network-broker:latest
         args:
         - -c
         - /conf/config.yaml


### PR DESCRIPTION
As of v0.25.0 and greater, the requirements for fixed values within the `config.yaml` file for the broker are **much** lighter. Specifying the default publicKey and allowedIps isn't necessary. The addition of the `--deployment-id` flag in #72 means that the broker can be started with very minimal configuration needs, and will load the default config from https://semgrep.dev/api/broker/16/default-config instead (where `16` is the deployment/org id).

Our docs overall (both this repo's README.md and https://semgrep.dev/docs/semgrep-ci/network-broker) don't reflect this potential simplicity and overall, need an update and reconciliation so that the same info is available in both.

Technically, this example could be _further_ simplified, and the config.yaml file completely removed. Only the `inbound:wireguard:privateKey` value is required. I opted to keep config.yaml present as it's likely users will want to tune the allowlist and SCM configuration.

**A future enhancement:** It's unclear to me if the github:* map is _even required_ for SMS functionality. We should do some lab testing to confirm or deny this. That could unlock further simplification.
edit: lab testing confirmed that at least the scm:baseURL: map is required for SMS to work via broker. But not the token: key.