### PR TITLE
chore(logs): Redact GitLab access tokens

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,11 @@ func init() {
 	// gitlab regex from semgrep-rules-secrets
 	rh := &redactrus.Hook{
 		AcceptedLevels: log.AllLevels,
-		RedactionList:  []string{"(oauth2:)gh[ps]_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|glpat-[a-zA-Z0-9-=_]{20,22}(@)"},
+		RedactionList: []string{
+			"(oauth2:)gh[ps]_[a-zA-Z0-9]{36}(@)",
+			"(oauth2:)github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}(@)",
+			"(oauth2:)glpat-[a-zA-Z0-9-=_]{20,22}(@)",
+		},
 	}
 
 	log.AddHook(rh)

--- a/main.go
+++ b/main.go
@@ -11,10 +11,11 @@ func init() {
 	// Create Redactrus hook that is triggered
 	// for every logger level and redacts
 	// github oauth tokens from logs
-	// regex source: https://gist.github.com/magnetikonline/073afe7909ffdd6f10ef06a00bc3bc88
+	// github regex source: https://gist.github.com/magnetikonline/073afe7909ffdd6f10ef06a00bc3bc88
+	// gitlab regex from semgrep-rules-secrets
 	rh := &redactrus.Hook{
 		AcceptedLevels: log.AllLevels,
-		RedactionList:  []string{"(oauth2:)gh[ps]_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}(@)"},
+		RedactionList:  []string{"(oauth2:)gh[ps]_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}|glpat-[a-zA-Z0-9-=_]{20,22}(@)"},
 	}
 
 	log.AddHook(rh)


### PR DESCRIPTION
SCM access tokens are sensitive and should not be logged (even though these are short-lived).