### PR TITLE
Set mtu to 1320 by default

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -90,7 +90,7 @@ type WireguardPeer struct {
 type WireguardBase struct {
 	LocalAddress                 string                `mapstructure:"localAddress" json:"localAddress" validate:"format=ip"`
 	Dns                          []string              `mapstructure:"dns" json:"dns" validate:"empty=true > format=ip"`
-	Mtu                          int                   `mapstructure:"mtu" json:"mtu" validate:"gte=0" default:"1420"`
+	Mtu                          int                   `mapstructure:"mtu" json:"mtu" validate:"gte=0" default:"1320"`
 	PrivateKey                   SensitiveBase64String `mapstructure:"privateKey" json:"privateKey" validate:"empty=false"`
 	ListenPort                   int                   `mapstructure:"listenPort" json:"listenPort" validate:"gte=0"`
 	Peers                        []WireguardPeer       `mapstructure:"peers" json:"peers" validate:"empty=false"`


### PR DESCRIPTION
The solutions engineering team has seen a number of occasions recently where the default MTU for `semgrep-network-broker` exhibits errors like `'TypeError("cannot pickle \'_thread.RLock\' object")'`. Setting the MTU value in the config.yaml to 1320 consistently resolves this.

I suggest we update the default MTU of the broker to `1320` to reflect common practice and provide ample overhead for wireguard headers.