### PR TITLE
Throw clear error when private key is an invalid length

### DIFF
--- a/cmd/pubkey.go
+++ b/cmd/pubkey.go
@@ -8,7 +8,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.zx2c4.com/wireguard/device"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
@@ -21,13 +20,13 @@ var pubkeyCmd = &cobra.Command{
 			log.Panic(err)
 		}
 
-		keyBytes := make([]byte, device.NoisePrivateKeySize)
+		keyBytes := make([]byte, wgtypes.KeyLen)
 		n, err := base64.StdEncoding.Decode(keyBytes, keyBase64)
 		if err != nil {
 			log.Panic(err)
 		}
-		if n != device.NoisePrivateKeySize {
-			log.Panic(fmt.Sprintf("expected private key to be %d bytes decoded, got %d", device.NoisePrivateKeySize, n))
+		if n != wgtypes.KeyLen {
+			log.Panic(fmt.Sprintf("expected private key to be %d bytes decoded, got %d", wgtypes.KeyLen, n))
 		}
 
 		privateKey, err := wgtypes.NewKey(keyBytes)

--- a/cmd/pubkey.go
+++ b/cmd/pubkey.go
@@ -8,10 +8,9 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.zx2c4.com/wireguard/device"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
-
-const privateKeyLength = 32
 
 var pubkeyCmd = &cobra.Command{
 	Use:   "pubkey",
@@ -22,13 +21,13 @@ var pubkeyCmd = &cobra.Command{
 			log.Panic(err)
 		}
 
-		keyBytes := make([]byte, privateKeyLength)
+		keyBytes := make([]byte, device.NoisePrivateKeySize)
 		n, err := base64.StdEncoding.Decode(keyBytes, keyBase64)
 		if err != nil {
 			log.Panic(err)
 		}
-		if n != privateKeyLength {
-			log.Panic(fmt.Sprintf("expected private key to be %d bytes decoded, got %d", privateKeyLength, n))
+		if n != device.NoisePrivateKeySize {
+			log.Panic(fmt.Sprintf("expected private key to be %d bytes decoded, got %d", device.NoisePrivateKeySize, n))
 		}
 
 		privateKey, err := wgtypes.NewKey(keyBytes)

--- a/cmd/pubkey.go
+++ b/cmd/pubkey.go
@@ -11,6 +11,8 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
+const privateKeyLength = 32
+
 var pubkeyCmd = &cobra.Command{
 	Use:   "pubkey",
 	Short: "Reads a base64 private key from stdin, outputs the corresponding base64 public key",
@@ -20,13 +22,13 @@ var pubkeyCmd = &cobra.Command{
 			log.Panic(err)
 		}
 
-		keyBytes := make([]byte, 32)
+		keyBytes := make([]byte, privateKeyLength)
 		n, err := base64.StdEncoding.Decode(keyBytes, keyBase64)
 		if err != nil {
 			log.Panic(err)
 		}
-		if n != 32 {
-			log.Panic("not enough bytes")
+		if n != privateKeyLength {
+			log.Panic(fmt.Sprintf("expected private key to be %d bytes decoded, got %d", privateKeyLength, n))
 		}
 
 		privateKey, err := wgtypes.NewKey(keyBytes)


### PR DESCRIPTION
When the `pubkey` command is called on a private key which decodes to a length other than 32, we throw an opaque "not enough bytes" error.

Update the error message to include context and the calculated private key length to aid debugging.