### PR TITLE
Update CODEOWNERS to reflect current owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,1 @@
-* @matthewdean-semgrep
-* @zyannes
-* @vivekkhimani
-* @tpetr
+* @matthewdean-semgrep @kpurdon @chmccreery


### PR DESCRIPTION
When there are multiple matching rules the last takes precedence, meaning Tom was assigned as reviewer to all pull requests by default. This changes it so @matthewdean-semgrep, @kpurdon, and @chmccreery are assigned as code reviewers instead.