### PR TITLE
Fix race condition in inbound proxy startup

### DIFF
--- a/pkg/inbound_proxy.go
+++ b/pkg/inbound_proxy.go
@@ -143,11 +143,15 @@ func (config *InboundProxyConfig) Start(tnet *netstack.Net) error {
 	})
 
 	// its showtime!
+	readyCh := make(chan struct{})
 	go func() {
 		wireguardListener, err := tnet.ListenTCP(&net.TCPAddr{Port: config.ProxyListenPort})
 		if err != nil {
 			log.Panic(fmt.Errorf("failed to start TCP listener: %v", err))
 		}
+
+		log.Info("broker.start")
+		close(readyCh)
 
 		err = r.RunListener(wireguardListener)
 		if err != nil {
@@ -155,7 +159,7 @@ func (config *InboundProxyConfig) Start(tnet *netstack.Net) error {
 		}
 	}()
 
-	log.Info("broker.start")
+	<-readyCh
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes a race condition in `TestWireguardInboundProxy` where the test would occasionally fail with "connection refused" on the first request.

## Root Cause

The `InboundProxyConfig.Start()` function was launching a goroutine to create the TCP listener and start the HTTP server, but returned immediately without waiting for the listener to be ready. This caused tests to occasionally make requests before the server was ready to accept connections.

## Solution

Added channel-based synchronization to ensure the TCP listener is created before `Start()` returns. The function now waits for the listener to be ready before completing.

## Test Results

Verified the fix by running the test 50 times successfully with no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)