### PR TITLE
Fix additionalCACerts variable shadowing bug

### DIFF
--- a/pkg/http_client.go
+++ b/pkg/http_client.go
@@ -29,7 +29,8 @@ func (hcc *HttpClientConfig) BuildRoundTripper() (http.RoundTripper, error) {
 	var certPool *x509.CertPool // nil certPool == use default system certs
 
 	if len(hcc.AdditionalCACerts) > 0 {
-		certPool, err := x509.SystemCertPool()
+		var err error
+		certPool, err = x509.SystemCertPool()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The `:=` operator in `BuildRoundTripper()` was creating a new scoped `certPool` variable that shadowed the outer one. Custom CA certs were being loaded into the inner variable, but the outer `certPool` (still `nil`) was used in the TLS config, causing `additionalCACerts` to be silently ignored.

```go
var certPool *x509.CertPool // line 29: outer variable

if len(hcc.AdditionalCACerts) > 0 {
    certPool, err := x509.SystemCertPool()  // BUG: shadows outer certPool
    // ... certs appended to inner certPool ...
}

transport.TLSClientConfig = &tls.Config{
    RootCAs: certPool,  // uses outer certPool, which is still nil
}
```

This bug was introduced in #147 when the `TLSClientConfig` assignment was moved outside the `if` block but the `:=` was not changed to `=`.

Fixes #198