### PR TITLE
Update Default GitHub Allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Adding a `github` field to the config implicitly adds these endpoints to the all
 - POST `https://github.example.com/api/v3/app/installations/:id/access_tokens`
 - POST `https://github.example.com/api/v3/orgs/:org/hooks`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/check-runs`
+- POST `https://github.example.com/api/v3/repos/:owner/:repo/git/refs`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/issues/:number/comments`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/pulls/:number/comments`
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/pulls/:number/comments/:comment_id/replies`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -664,6 +664,11 @@ func PopulateAllowLists(config *Config) error {
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/repos/:owner/:repo/git/refs").String(),
+				Methods:           ParseHttpMethods([]string{"POST"}),
+				SetRequestHeaders: headers,
+			},
 		)
 
 		if config.Inbound.GitHub.AllowCodeAccess {


### PR DESCRIPTION
Updating the default GitHub Allowlist to include a new endpoint which is used by c2f SAST.