### PR TITLE
feat(allowlist): add branch check endpoints for all SCM providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Adding a `github` field to the config implicitly adds these endpoints to the all
 - GET `https://github.example.com/api/v3/repos/:org/:repo/actions/secrets/public-key`
 - GET `https://github.example.com/api/v3/repos/:owner/:repo`
 - GET `https://github.example.com/api/v3/repos/:owner/:repo/branches`
+- GET `https://github.example.com/api/v3/repos/:owner/:repo/branches/:branch`
 - GET `https://github.example.com/api/v3/repos/:owner/:repo/collaborators/:username/permission`
 - GET `https://github.example.com/api/v3/repos/:owner/:repo/compare/:basehead`
 - GET `https://github.example.com/api/v3/repos/:owner/:repo/contents/.github/workflows/semgrep.yml`
@@ -190,6 +191,7 @@ Adding a `gitlab` field to the config implicitly adds these endpoints to the all
 - GET `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions/:discussion/notes/:note/award_emoji`
 - GET `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/versions`
 - GET `https://gitlab.example.com/api/v4/projects/:project/repository/branches`
+- GET `https://gitlab.example.com/api/v4/projects/:project/repository/branches/:branch`
 - POST `https://gitlab.example.com/api/v4/groups/:namespace/hooks`
 - POST `https://gitlab.example.com/api/v4/projects/:project/hooks`
 - POST `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions`
@@ -233,6 +235,7 @@ Adding a `bitbucket` field to the config implicitly adds these endpoints to the 
 - GET `https://bitbucket.example.com/rest/api/latest/projects/:project`
 - GET `https://bitbucket.example.com/rest/api/latest/projects/:project/repos`
 - GET `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo`
+- GET `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/branches`
 - GET `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/default-branch`
 - GET `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/pull-requests`
 - GET `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/pull-requests/:number/comments/:comment`
@@ -278,6 +281,7 @@ Adding a `azuredevops` field to the config implicitly adds these endpoints to th
 - GET `https://dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests`
 - GET `https://dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests/:number/iterations`
 - GET `https://dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests/:number/iterations/:iterationId/changes`
+- GET `https://dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/refs`
 - GET `https://dev.azure.com/:namespace/:project/_apis/hooks/subscriptions`
 - GET `https://dev.azure.com/:namespace/_apis/connectionData`
 - GET `https://dev.azure.com/:namespace/_apis/projects/:project`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -504,6 +504,12 @@ func PopulateAllowLists(config *Config) error {
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
+			// get branch
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/repos/:owner/:repo/branches/:branch").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
 			// post issue comment
 			AllowlistItem{
 				URL:               gitHubBaseUrl.JoinPath("/repos/:owner/:repo/issues/:number/comments").String(),
@@ -820,6 +826,12 @@ func PopulateAllowLists(config *Config) error {
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
+			// Get branch
+			AllowlistItem{
+				URL:               gitLabBaseUrl.JoinPath("/projects/:project/repository/branches/:branch").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
 			// post MR comment
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/projects/:project/merge_requests/:number/discussions").String(),
@@ -975,6 +987,12 @@ func PopulateAllowLists(config *Config) error {
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
+			// list branches (used for branch existence check with filterText)
+			AllowlistItem{
+				URL:               bitBucketBaseUrl.JoinPath("/projects/:project/repos/:repo/branches").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
 			// pull requests
 			AllowlistItem{
 				URL:               bitBucketBaseUrl.JoinPath("/projects/:project/repos/:repo/pull-requests").String(),
@@ -1104,6 +1122,12 @@ func PopulateAllowLists(config *Config) error {
 			// repo info
 			AllowlistItem{
 				URL:               azureDevOpsBaseUrl.JoinPath("/:namespace/:project/_apis/git/repositories/:repo").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
+			// get refs (used for branch existence check)
+			AllowlistItem{
+				URL:               azureDevOpsBaseUrl.JoinPath("/:namespace/:project/_apis/git/repositories/:repo/refs").String(),
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},


### PR DESCRIPTION
## Why
semgrep/semgrep-app#27686 adds `check_branch_exists()` calls for all SCM providers. Without allowlist entries, these calls are blocked by the network broker for on-prem customers, causing the branch check to silently fail-open.

## What
- **GitHub**: `GET /repos/:owner/:repo/branches/:branch`
- **GitLab**: `GET /projects/:project/repository/branches/:branch`
- **Bitbucket Datacenter**: `GET /projects/:project/repos/:repo/branches` (uses filterText query param)
- **Azure DevOps**: `GET /:namespace/:project/_apis/git/repositories/:repo/refs` (uses filter query param)

Note: Bitbucket Cloud uses `api.bitbucket.org` (public API) and doesn't go through the broker.

## Related PRs
- semgrep/semgrep-app#27686 — pre-dispatch branch validation (depends on this)

## Deployment Order
This PR should be merged/deployed before or alongside semgrep/semgrep-app#27686.