### PR TITLE
feat: add setup and test CLI commands

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/semgrep/semgrep-network-broker/pkg"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const semgrepAppTokenEnvVar = "SEMGREP_APP_TOKEN"
+
+var setupToken string
+var setupOutput string
+
+var setupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Automatically configure the broker with a single command",
+	Long: `Generates a WireGuard keypair, registers it with the Semgrep backend,
+fetches the default configuration, and writes a complete config.yaml.
+
+Requires a Semgrep App Token (via --token or SEMGREP_APP_TOKEN env var)
+and a deployment ID (--deployment-id).
+
+Example:
+  semgrep-network-broker setup --token <SEMGREP_APP_TOKEN> --deployment-id 12345
+  SEMGREP_APP_TOKEN=<token> semgrep-network-broker setup -d 12345 --output /etc/broker/config.yaml`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if jsonLog {
+			log.SetFormatter(&log.JSONFormatter{FieldMap: log.FieldMap{log.FieldKeyMsg: "event"}})
+		}
+
+		token := setupToken
+		if token == "" {
+			token = os.Getenv(semgrepAppTokenEnvVar)
+		}
+		if token == "" {
+			log.Panic("--token or SEMGREP_APP_TOKEN env var is required")
+		}
+
+		if deploymentId <= 0 {
+			log.Panic("--deployment-id is required")
+		}
+
+		// Step 1: Generate WireGuard keypair
+		fmt.Println("Generating WireGuard keypair...")
+		privateKeyB64, publicKeyB64, err := pkg.GenerateKeyPair()
+		if err != nil {
+			log.Panic(fmt.Errorf("failed to generate keypair: %v", err))
+		}
+		fmt.Printf("  Public key: %s\n", publicKeyB64)
+
+		// Step 2: Register public key with Semgrep
+		fmt.Println("Registering broker with Semgrep backend...")
+		instance, err := pkg.RegisterBrokerInstance(deploymentId, publicKeyB64, token)
+		if err != nil {
+			log.Panic(fmt.Errorf("failed to register broker instance: %v", err))
+		}
+		fmt.Printf("  Assigned peer IP: %s\n", instance.PeerIp)
+
+		// Step 3: Fetch default config
+		fmt.Println("Fetching default configuration...")
+		defaultConfigJSON, err := pkg.FetchDefaultConfig(deploymentId)
+		if err != nil {
+			log.Panic(fmt.Errorf("failed to fetch default config: %v", err))
+		}
+
+		// Step 4: Build complete config YAML
+		configYAML, err := pkg.BuildConfigYAML(defaultConfigJSON, privateKeyB64, instance.PeerIp)
+		if err != nil {
+			log.Panic(fmt.Errorf("failed to build config YAML: %v", err))
+		}
+
+		// Step 5: Write config to disk
+		if err := os.WriteFile(setupOutput, configYAML, 0600); err != nil {
+			log.Panic(fmt.Errorf("failed to write config file: %v", err))
+		}
+		fmt.Printf("Config written to: %s\n", setupOutput)
+		fmt.Println()
+
+		// Step 6: Verify connectivity using the generated config
+		fmt.Println("Verifying connectivity...")
+		config, err := pkg.LoadConfig([]string{setupOutput}, deploymentId)
+		if err != nil {
+			fmt.Printf("Warning: could not load generated config for verification: %v\n", err)
+			printManualTestHint(setupOutput, deploymentId)
+			return
+		}
+
+		results, err := pkg.TestConnectivity(config)
+		if err != nil {
+			fmt.Printf("Warning: connectivity test failed to start: %v\n", err)
+			printManualTestHint(setupOutput, deploymentId)
+			return
+		}
+
+		pkg.PrintTestResults(results)
+
+		if len(results) > 0 && pkg.AllPassed(results) {
+			fmt.Println("\nSetup complete. Your broker is ready to use.")
+		} else {
+			fmt.Println("\nSetup complete. Config file written, but some connectivity tests did not pass.")
+		}
+
+		fmt.Println()
+		fmt.Println("Next steps:")
+		fmt.Printf("  1. Edit %s to add your SCM configuration (github, gitlab, etc.)\n", setupOutput)
+		fmt.Printf("  2. Run: semgrep-network-broker test -c %s -d %d\n", setupOutput, deploymentId)
+		fmt.Printf("  3. Start the broker: semgrep-network-broker -c %s -d %d\n", setupOutput, deploymentId)
+	},
+}
+
+func printManualTestHint(configPath string, deplId int) {
+	fmt.Println("The config file was written successfully. You can test manually with:")
+	fmt.Printf("  semgrep-network-broker test -c %s -d %d\n", configPath, deplId)
+}
+
+func init() {
+	setupCmd.Flags().StringVar(&setupToken, "token", "", "Semgrep App Token (or set SEMGREP_APP_TOKEN env var)")
+	setupCmd.Flags().StringVar(&setupOutput, "output", "config.yaml", "path to write the generated config file")
+	rootCmd.AddCommand(setupCmd)
+}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/semgrep/semgrep-network-broker/pkg"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var testCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Test broker connectivity to Semgrep and configured SCMs",
+	Long: `Establishes the WireGuard tunnel and verifies that the broker can reach
+the Semgrep heartbeat endpoint and each configured source code manager.
+
+A non-zero exit code indicates one or more targets are unreachable.
+An HTTP 401/403 response is still considered a PASS (proves network path works).`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if jsonLog {
+			log.SetFormatter(&log.JSONFormatter{FieldMap: log.FieldMap{log.FieldKeyMsg: "event"}})
+		}
+
+		config, err := pkg.LoadConfig(configFiles, deploymentId)
+		if err != nil {
+			log.Panic(err)
+		}
+
+		fmt.Println("Starting connectivity test...")
+		fmt.Printf("WireGuard local address: %s\n", config.Inbound.Wireguard.LocalAddress)
+
+		results, err := pkg.TestConnectivity(config)
+		if err != nil {
+			log.Panic(fmt.Errorf("connectivity test failed to start: %v", err))
+		}
+
+		pkg.PrintTestResults(results)
+
+		if len(results) == 0 {
+			fmt.Println("\nNo targets configured to test. Add SCM configs (github, gitlab, etc.) to your config file.")
+			os.Exit(1)
+		}
+
+		if !pkg.AllPassed(results) {
+			fmt.Println("\nSome connectivity tests failed. Check your network configuration and firewall rules.")
+			os.Exit(1)
+		}
+
+		fmt.Println("\nAll connectivity tests passed.")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(testCmd)
+}

--- a/pkg/connectivity.go
+++ b/pkg/connectivity.go
@@ -1,0 +1,157 @@
+package pkg
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.zx2c4.com/wireguard/tun/netstack"
+)
+
+// TestResult holds the result of a single connectivity test.
+type TestResult struct {
+	Name       string
+	URL        string
+	Reachable  bool
+	StatusCode int
+	Latency    time.Duration
+	Error      string
+}
+
+// SCMTarget describes an SCM endpoint to test.
+type SCMTarget struct {
+	Name    string
+	BaseURL string
+}
+
+// CollectSCMTargets extracts configured SCM endpoints from the config.
+func CollectSCMTargets(config *Config) []SCMTarget {
+	var targets []SCMTarget
+	if config.Inbound.GitHub != nil && config.Inbound.GitHub.BaseURL != "" {
+		targets = append(targets, SCMTarget{Name: "GitHub", BaseURL: config.Inbound.GitHub.BaseURL})
+	}
+	if config.Inbound.GitLab != nil && config.Inbound.GitLab.BaseURL != "" {
+		targets = append(targets, SCMTarget{Name: "GitLab", BaseURL: config.Inbound.GitLab.BaseURL})
+	}
+	if config.Inbound.BitBucket != nil && config.Inbound.BitBucket.BaseURL != "" {
+		targets = append(targets, SCMTarget{Name: "BitBucket", BaseURL: config.Inbound.BitBucket.BaseURL})
+	}
+	if config.Inbound.AzureDevOps != nil && config.Inbound.AzureDevOps.BaseURL != "" {
+		targets = append(targets, SCMTarget{Name: "AzureDevOps", BaseURL: config.Inbound.AzureDevOps.BaseURL})
+	}
+	return targets
+}
+
+// TestConnectivity brings up the WireGuard tunnel and tests connectivity
+// to the heartbeat endpoint and each configured SCM.
+func TestConnectivity(config *Config) ([]TestResult, error) {
+	tnet, teardown, err := config.Inbound.Wireguard.Start()
+	if err != nil {
+		return nil, fmt.Errorf("failed to start WireGuard tunnel: %v", err)
+	}
+	defer teardown()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: tnet.DialContext,
+		},
+		Timeout: 10 * time.Second,
+	}
+
+	var results []TestResult
+
+	if config.Inbound.Heartbeat.URL != "" {
+		results = append(results, testEndpoint(client, tnet, "Heartbeat", config.Inbound.Heartbeat.URL))
+	}
+
+	for _, target := range CollectSCMTargets(config) {
+		results = append(results, testEndpoint(client, tnet, target.Name, target.BaseURL))
+	}
+
+	return results, nil
+}
+
+func testEndpoint(client *http.Client, tnet *netstack.Net, name string, targetURL string) TestResult {
+	start := time.Now()
+	req, err := http.NewRequest("GET", targetURL, nil)
+	if err != nil {
+		return TestResult{
+			Name:  name,
+			URL:   targetURL,
+			Error: fmt.Sprintf("invalid URL: %v", err),
+		}
+	}
+
+	resp, err := client.Do(req)
+	latency := time.Since(start)
+
+	if err != nil {
+		log.WithField("target", name).WithError(err).Debug("connectivity.test.failure")
+		return TestResult{
+			Name:    name,
+			URL:     targetURL,
+			Latency: latency,
+			Error:   err.Error(),
+		}
+	}
+	defer resp.Body.Close()
+
+	// Any HTTP response (even 401/403) proves network connectivity
+	log.WithField("target", name).WithField("status", resp.StatusCode).WithField("latency", latency).Debug("connectivity.test.success")
+
+	return TestResult{
+		Name:       name,
+		URL:        targetURL,
+		Reachable:  true,
+		StatusCode: resp.StatusCode,
+		Latency:    latency,
+	}
+}
+
+// PrintTestResults prints a formatted summary of test results.
+func PrintTestResults(results []TestResult) {
+	fmt.Println()
+	fmt.Println("Connectivity Test Results")
+	fmt.Println("─────────────────────────────────────────────────────────────────")
+	fmt.Printf("  %-14s %-8s %-10s %-8s %s\n", "TARGET", "STATUS", "HTTP CODE", "LATENCY", "DETAILS")
+	fmt.Println("─────────────────────────────────────────────────────────────────")
+
+	for _, r := range results {
+		status := "FAIL"
+		if r.Reachable {
+			status = "PASS"
+		}
+
+		httpCode := "-"
+		if r.StatusCode > 0 {
+			httpCode = fmt.Sprintf("%d", r.StatusCode)
+		}
+
+		latency := "-"
+		if r.Latency > 0 {
+			latency = r.Latency.Round(time.Millisecond).String()
+		}
+
+		details := ""
+		if r.Error != "" {
+			details = r.Error
+		} else if r.StatusCode == 401 || r.StatusCode == 403 {
+			details = "reachable (auth required)"
+		}
+
+		fmt.Printf("  %-14s %-8s %-10s %-8s %s\n", r.Name, status, httpCode, latency, details)
+	}
+
+	fmt.Println("─────────────────────────────────────────────────────────────────")
+}
+
+// AllPassed returns true if every test result was reachable.
+func AllPassed(results []TestResult) bool {
+	for _, r := range results {
+		if !r.Reachable {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/connectivity_test.go
+++ b/pkg/connectivity_test.go
@@ -1,0 +1,101 @@
+package pkg
+
+import (
+	"testing"
+)
+
+func TestCollectSCMTargets_NoSCMs(t *testing.T) {
+	config := &Config{}
+	targets := CollectSCMTargets(config)
+	if len(targets) != 0 {
+		t.Errorf("expected 0 targets, got %d", len(targets))
+	}
+}
+
+func TestCollectSCMTargets_AllSCMs(t *testing.T) {
+	config := &Config{
+		Inbound: InboundProxyConfig{
+			GitHub:      &GitHub{BaseURL: "https://github.example.com/api/v3"},
+			GitLab:      &GitLab{BaseURL: "https://gitlab.example.com/api/v4"},
+			BitBucket:   &BitBucket{BaseURL: "https://bitbucket.example.com"},
+			AzureDevOps: &AzureDevOps{BaseURL: "https://dev.azure.com/org"},
+		},
+	}
+	targets := CollectSCMTargets(config)
+	if len(targets) != 4 {
+		t.Errorf("expected 4 targets, got %d", len(targets))
+	}
+
+	expected := []struct {
+		name    string
+		baseURL string
+	}{
+		{"GitHub", "https://github.example.com/api/v3"},
+		{"GitLab", "https://gitlab.example.com/api/v4"},
+		{"BitBucket", "https://bitbucket.example.com"},
+		{"AzureDevOps", "https://dev.azure.com/org"},
+	}
+
+	for i, e := range expected {
+		if targets[i].Name != e.name {
+			t.Errorf("target[%d] name: got %q, want %q", i, targets[i].Name, e.name)
+		}
+		if targets[i].BaseURL != e.baseURL {
+			t.Errorf("target[%d] baseURL: got %q, want %q", i, targets[i].BaseURL, e.baseURL)
+		}
+	}
+}
+
+func TestCollectSCMTargets_EmptyBaseURL(t *testing.T) {
+	config := &Config{
+		Inbound: InboundProxyConfig{
+			GitHub: &GitHub{BaseURL: ""},
+			GitLab: &GitLab{BaseURL: "https://gitlab.example.com/api/v4"},
+		},
+	}
+	targets := CollectSCMTargets(config)
+	if len(targets) != 1 {
+		t.Errorf("expected 1 target, got %d", len(targets))
+	}
+	if targets[0].Name != "GitLab" {
+		t.Errorf("expected GitLab, got %s", targets[0].Name)
+	}
+}
+
+func TestCollectSCMTargets_PartialSCMs(t *testing.T) {
+	config := &Config{
+		Inbound: InboundProxyConfig{
+			GitHub: &GitHub{BaseURL: "https://github.example.com/api/v3"},
+		},
+	}
+	targets := CollectSCMTargets(config)
+	if len(targets) != 1 {
+		t.Errorf("expected 1 target, got %d", len(targets))
+	}
+}
+
+func TestAllPassed_AllPass(t *testing.T) {
+	results := []TestResult{
+		{Name: "a", Reachable: true},
+		{Name: "b", Reachable: true},
+	}
+	if !AllPassed(results) {
+		t.Error("expected AllPassed to return true")
+	}
+}
+
+func TestAllPassed_OneFail(t *testing.T) {
+	results := []TestResult{
+		{Name: "a", Reachable: true},
+		{Name: "b", Reachable: false, Error: "timeout"},
+	}
+	if AllPassed(results) {
+		t.Error("expected AllPassed to return false")
+	}
+}
+
+func TestAllPassed_Empty(t *testing.T) {
+	if !AllPassed(nil) {
+		t.Error("expected AllPassed to return true for empty results")
+	}
+}

--- a/pkg/setup.go
+++ b/pkg/setup.go
@@ -1,0 +1,246 @@
+package pkg
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	log "github.com/sirupsen/logrus"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+// BrokerInstance matches the proto BrokerInstance message returned by the API.
+type BrokerInstance struct {
+	DeploymentId  uint64 `json:"deployment_id"`
+	PublicKey     string `json:"public_key"`
+	PeerIp        string `json:"peer_ip"`
+	AddressOffset int32  `json:"address_offset"`
+}
+
+// RegisterBrokerInstanceResponse is the JSON response from the register API.
+type RegisterBrokerInstanceResponse struct {
+	Config BrokerInstance `json:"config"`
+}
+
+// GenerateKeyPair generates a new WireGuard private/public key pair.
+// Returns (privateKeyBase64, publicKeyBase64, error).
+func GenerateKeyPair() (string, string, error) {
+	privateKey, err := wgtypes.GeneratePrivateKey()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to generate private key: %v", err)
+	}
+
+	publicKey := privateKey.PublicKey()
+	privB64 := base64.StdEncoding.EncodeToString(privateKey[:])
+	pubB64 := base64.StdEncoding.EncodeToString(publicKey[:])
+
+	return privB64, pubB64, nil
+}
+
+// RegisterBrokerInstance registers a WireGuard public key with the Semgrep backend
+// and returns the assigned broker instance configuration.
+func RegisterBrokerInstance(deploymentId int, publicKey string, appToken string) (*BrokerInstance, error) {
+	hostname := getSemgrepHostname()
+
+	apiURL := url.URL{
+		Scheme: "https",
+		Host:   hostname,
+		Path:   fmt.Sprintf("/api/broker/v1/%d/config", deploymentId),
+	}
+
+	body := map[string]interface{}{
+		"deployment_id": deploymentId,
+		"public_key":    publicKey,
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", apiURL.String(), bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", appToken))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register broker instance: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to register broker instance: HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result RegisterBrokerInstanceResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %v", err)
+	}
+
+	log.WithField("peer_ip", result.Config.PeerIp).Info("setup.registered")
+	return &result.Config, nil
+}
+
+// FetchDefaultConfig fetches the default broker config from the Semgrep backend.
+// Returns the raw JSON bytes.
+func FetchDefaultConfig(deploymentId int) ([]byte, error) {
+	hostname := getSemgrepHostname()
+
+	apiURL := url.URL{
+		Scheme: "https",
+		Host:   hostname,
+		Path:   fmt.Sprintf("/api/broker/v1/%d/default-config", deploymentId),
+	}
+
+	resp, err := http.DefaultClient.Get(apiURL.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch default config from %s: %v", hostname, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch default config: HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read default config response: %v", err)
+	}
+
+	return body, nil
+}
+
+// BuildConfigYAML generates a complete broker config YAML file from the default
+// config, the generated private key, and the assigned local address.
+func BuildConfigYAML(defaultConfigJSON []byte, privateKeyB64 string, localAddress string) ([]byte, error) {
+	// Parse the default config to extract wireguard peer info and heartbeat
+	var defaultConfig struct {
+		Config struct {
+			Inbound struct {
+				Wireguard struct {
+					Peers []struct {
+						PublicKey                   string `json:"public_key"`
+						Endpoint                    string `json:"endpoint"`
+						AllowedIps                  string `json:"allowed_ips"`
+						PersistentKeepaliveInterval int    `json:"persistent_keepalive_interval"`
+					} `json:"peers"`
+					Mtu        int      `json:"mtu"`
+					ListenPort int      `json:"listen_port"`
+					Dns        []string `json:"dns"`
+				} `json:"wireguard"`
+				Heartbeat struct {
+					URL                       string `json:"url"`
+					IntervalSeconds           int    `json:"interval_seconds"`
+					TimeoutSeconds            int    `json:"timeout_seconds"`
+					PanicAfterFailureCount    int    `json:"panic_after_failure_count"`
+					FirstHeartbeatMustSucceed bool   `json:"first_heartbeat_must_succeed"`
+				} `json:"heartbeat"`
+				Allowlist []struct {
+					URL     string   `json:"url"`
+					Methods []string `json:"methods"`
+				} `json:"allowlist"`
+				ProxyListenPort int `json:"proxy_listen_port"`
+			} `json:"inbound"`
+		} `json:"config"`
+	}
+
+	if err := json.Unmarshal(defaultConfigJSON, &defaultConfig); err != nil {
+		return nil, fmt.Errorf("failed to parse default config JSON: %v", err)
+	}
+
+	inbound := defaultConfig.Config.Inbound
+
+	// Build YAML manually for clean, readable output
+	var buf bytes.Buffer
+	buf.WriteString("# Semgrep Network Broker Configuration\n")
+	buf.WriteString("# Generated by: semgrep-network-broker setup\n")
+	buf.WriteString("# Documentation: https://semgrep.dev/docs/semgrep-ci/network-broker\n")
+	buf.WriteString("#\n")
+	buf.WriteString("# WARNING: Do not share the privateKey value with anyone, including Semgrep.\n")
+	buf.WriteString("\n")
+	buf.WriteString("inbound:\n")
+	buf.WriteString("  wireguard:\n")
+	buf.WriteString(fmt.Sprintf("    localAddress: \"%s\"\n", localAddress))
+	buf.WriteString(fmt.Sprintf("    privateKey: \"%s\"\n", privateKeyB64))
+
+	if inbound.Wireguard.Mtu > 0 {
+		buf.WriteString(fmt.Sprintf("    mtu: %d\n", inbound.Wireguard.Mtu))
+	}
+	if inbound.Wireguard.ListenPort > 0 {
+		buf.WriteString(fmt.Sprintf("    listenPort: %d\n", inbound.Wireguard.ListenPort))
+	}
+	if len(inbound.Wireguard.Dns) > 0 {
+		buf.WriteString("    dns:\n")
+		for _, dns := range inbound.Wireguard.Dns {
+			buf.WriteString(fmt.Sprintf("      - \"%s\"\n", dns))
+		}
+	}
+
+	if len(inbound.Wireguard.Peers) > 0 {
+		buf.WriteString("    peers:\n")
+		for _, peer := range inbound.Wireguard.Peers {
+			buf.WriteString(fmt.Sprintf("      - publicKey: \"%s\"\n", peer.PublicKey))
+			if peer.Endpoint != "" {
+				buf.WriteString(fmt.Sprintf("        endpoint: \"%s\"\n", peer.Endpoint))
+			}
+			if peer.AllowedIps != "" {
+				buf.WriteString(fmt.Sprintf("        allowedIps: \"%s\"\n", peer.AllowedIps))
+			}
+			if peer.PersistentKeepaliveInterval > 0 {
+				buf.WriteString(fmt.Sprintf("        persistentKeepaliveInterval: %d\n", peer.PersistentKeepaliveInterval))
+			}
+		}
+	}
+
+	// Heartbeat
+	if inbound.Heartbeat.URL != "" {
+		buf.WriteString("\n  heartbeat:\n")
+		buf.WriteString(fmt.Sprintf("    url: \"%s\"\n", inbound.Heartbeat.URL))
+		if inbound.Heartbeat.IntervalSeconds > 0 {
+			buf.WriteString(fmt.Sprintf("    intervalSeconds: %d\n", inbound.Heartbeat.IntervalSeconds))
+		}
+		if inbound.Heartbeat.TimeoutSeconds > 0 {
+			buf.WriteString(fmt.Sprintf("    timeoutSeconds: %d\n", inbound.Heartbeat.TimeoutSeconds))
+		}
+		if inbound.Heartbeat.FirstHeartbeatMustSucceed {
+			buf.WriteString("    firstHeartbeatMustSucceed: true\n")
+		}
+	}
+
+	// Proxy listen port
+	if inbound.ProxyListenPort > 0 {
+		buf.WriteString(fmt.Sprintf("\n  proxyListenPort: %d\n", inbound.ProxyListenPort))
+	}
+
+	// SCM placeholders
+	buf.WriteString("\n  # Uncomment and configure the SCMs you need:\n")
+	buf.WriteString("  #\n")
+	buf.WriteString("  # github:\n")
+	buf.WriteString("  #   baseUrl: https://github.example.com/api/v3\n")
+	buf.WriteString("  #   allowCodeAccess: false\n")
+	buf.WriteString("  #\n")
+	buf.WriteString("  # gitlab:\n")
+	buf.WriteString("  #   baseUrl: https://gitlab.example.com/api/v4\n")
+	buf.WriteString("  #   allowCodeAccess: false\n")
+	buf.WriteString("  #\n")
+	buf.WriteString("  # bitbucket:\n")
+	buf.WriteString("  #   baseUrl: https://bitbucket.example.com\n")
+	buf.WriteString("  #   allowCodeAccess: false\n")
+	buf.WriteString("  #\n")
+	buf.WriteString("  # azuredevops:\n")
+	buf.WriteString("  #   baseUrl: https://dev.azure.com/your-org\n")
+	buf.WriteString("  #   allowCodeAccess: false\n")
+
+	return buf.Bytes(), nil
+}

--- a/pkg/setup_test.go
+++ b/pkg/setup_test.go
@@ -1,0 +1,256 @@
+package pkg
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGenerateKeyPair(t *testing.T) {
+	priv, pub, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair failed: %v", err)
+	}
+
+	// Both should be valid base64
+	privBytes, err := base64.StdEncoding.DecodeString(priv)
+	if err != nil {
+		t.Errorf("private key is not valid base64: %v", err)
+	}
+	pubBytes, err := base64.StdEncoding.DecodeString(pub)
+	if err != nil {
+		t.Errorf("public key is not valid base64: %v", err)
+	}
+
+	// WireGuard keys are 32 bytes
+	if len(privBytes) != 32 {
+		t.Errorf("private key length: got %d, want 32", len(privBytes))
+	}
+	if len(pubBytes) != 32 {
+		t.Errorf("public key length: got %d, want 32", len(pubBytes))
+	}
+
+	// Keys should be different
+	if priv == pub {
+		t.Error("private and public keys should be different")
+	}
+
+	// Two calls should produce different keys
+	priv2, pub2, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("second GenerateKeyPair failed: %v", err)
+	}
+	if priv == priv2 {
+		t.Error("consecutive calls produced the same private key")
+	}
+	if pub == pub2 {
+		t.Error("consecutive calls produced the same public key")
+	}
+}
+
+func TestRegisterBrokerInstance(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/api/broker/v1/123/config") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("unexpected auth header: %s", r.Header.Get("Authorization"))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("unexpected content type: %s", r.Header.Get("Content-Type"))
+		}
+
+		// Parse request body
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("failed to parse request body: %v", err)
+		}
+		if body["public_key"] != "test-pub-key" {
+			t.Errorf("unexpected public_key: %v", body["public_key"])
+		}
+
+		// Return response
+		resp := RegisterBrokerInstanceResponse{
+			Config: BrokerInstance{
+				DeploymentId:  123,
+				PublicKey:     "test-pub-key",
+				PeerIp:        "fdf0:59dc:33cf:9be8:0000:007b:0000:0001",
+				AddressOffset: 0,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	// Override hostname to use test server
+	// The function uses getSemgrepHostname() which reads SEMGREP_HOSTNAME env var
+	t.Setenv(SemgrepHostnameEnvVar, server.Listener.Addr().String())
+
+	// We need to use the test server's TLS client
+	originalClient := http.DefaultClient
+	http.DefaultClient = server.Client()
+	defer func() { http.DefaultClient = originalClient }()
+
+	instance, err := RegisterBrokerInstance(123, "test-pub-key", "test-token")
+	if err != nil {
+		t.Fatalf("RegisterBrokerInstance failed: %v", err)
+	}
+
+	if instance.PeerIp != "fdf0:59dc:33cf:9be8:0000:007b:0000:0001" {
+		t.Errorf("unexpected peer_ip: %s", instance.PeerIp)
+	}
+	if instance.PublicKey != "test-pub-key" {
+		t.Errorf("unexpected public_key: %s", instance.PublicKey)
+	}
+}
+
+func TestRegisterBrokerInstance_Error(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, "access denied")
+	}))
+	defer server.Close()
+
+	t.Setenv(SemgrepHostnameEnvVar, server.Listener.Addr().String())
+	originalClient := http.DefaultClient
+	http.DefaultClient = server.Client()
+	defer func() { http.DefaultClient = originalClient }()
+
+	_, err := RegisterBrokerInstance(123, "test-pub-key", "bad-token")
+	if err == nil {
+		t.Fatal("expected error for 403 response")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error should mention status code: %v", err)
+	}
+}
+
+func TestFetchDefaultConfig(t *testing.T) {
+	expectedConfig := `{"config":{"inbound":{"wireguard":{"peers":[{"public_key":"abc123"}]}}}}`
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/api/broker/v1/456/default-config") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, expectedConfig)
+	}))
+	defer server.Close()
+
+	t.Setenv(SemgrepHostnameEnvVar, server.Listener.Addr().String())
+	originalClient := http.DefaultClient
+	http.DefaultClient = server.Client()
+	defer func() { http.DefaultClient = originalClient }()
+
+	body, err := FetchDefaultConfig(456)
+	if err != nil {
+		t.Fatalf("FetchDefaultConfig failed: %v", err)
+	}
+
+	if string(body) != expectedConfig {
+		t.Errorf("unexpected body: %s", string(body))
+	}
+}
+
+func TestBuildConfigYAML(t *testing.T) {
+	defaultConfigJSON := `{
+		"config": {
+			"inbound": {
+				"wireguard": {
+					"peers": [{
+						"public_key": "serverPubKey123",
+						"endpoint": "wireguard.semgrep.dev:51820",
+						"allowed_ips": "::/0",
+						"persistent_keepalive_interval": 20
+					}],
+					"mtu": 1320
+				},
+				"heartbeat": {
+					"url": "https://semgrep.dev/api/broker/heartbeat",
+					"interval_seconds": 60,
+					"timeout_seconds": 5
+				},
+				"proxy_listen_port": 80
+			}
+		}
+	}`
+
+	yaml, err := BuildConfigYAML([]byte(defaultConfigJSON), "privateKey123==", "fdf0:59dc:33cf:9be8::1")
+	if err != nil {
+		t.Fatalf("BuildConfigYAML failed: %v", err)
+	}
+
+	output := string(yaml)
+
+	// Check key fields are present
+	checks := []string{
+		`localAddress: "fdf0:59dc:33cf:9be8::1"`,
+		`privateKey: "privateKey123=="`,
+		`publicKey: "serverPubKey123"`,
+		`endpoint: "wireguard.semgrep.dev:51820"`,
+		`allowedIps: "::/0"`,
+		`persistentKeepaliveInterval: 20`,
+		`mtu: 1320`,
+		`url: "https://semgrep.dev/api/broker/heartbeat"`,
+		`intervalSeconds: 60`,
+		`timeoutSeconds: 5`,
+		`proxyListenPort: 80`,
+		"WARNING: Do not share the privateKey",
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(output, check) {
+			t.Errorf("output missing expected string: %q", check)
+		}
+	}
+
+	// Check SCM placeholder comments are present
+	scmChecks := []string{
+		"# github:",
+		"# gitlab:",
+		"# bitbucket:",
+		"# azuredevops:",
+	}
+	for _, check := range scmChecks {
+		if !strings.Contains(output, check) {
+			t.Errorf("output missing SCM placeholder: %q", check)
+		}
+	}
+}
+
+func TestBuildConfigYAML_InvalidJSON(t *testing.T) {
+	_, err := BuildConfigYAML([]byte("not json"), "key", "addr")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestBuildConfigYAML_EmptyConfig(t *testing.T) {
+	yaml, err := BuildConfigYAML([]byte(`{"config":{"inbound":{"wireguard":{}}}}`), "key==", "::1")
+	if err != nil {
+		t.Fatalf("BuildConfigYAML failed: %v", err)
+	}
+
+	output := string(yaml)
+	if !strings.Contains(output, `privateKey: "key=="`) {
+		t.Error("output missing privateKey")
+	}
+	if !strings.Contains(output, `localAddress: "::1"`) {
+		t.Error("output missing localAddress")
+	}
+	// Should not contain peers section when empty
+	if strings.Contains(output, "peers:") {
+		t.Error("output should not contain peers section when no peers configured")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `semgrep-network-broker setup` command that automates the entire broker setup process: generates WireGuard keypair, registers with Semgrep backend, fetches default config, writes `config.yaml`, and runs a connectivity test — all in one step.
- Adds `semgrep-network-broker test` command that loads config, brings up the WireGuard tunnel, and verifies connectivity to the heartbeat endpoint and each configured SCM. Any HTTP response (including 401/403) is treated as PASS since it proves the network path works.
- Includes unit tests for key generation, API registration (with httptest server mocking), config YAML building, SCM target collection, and result evaluation.

### Before (5+ manual steps)
```
semgrep-network-broker genkey → copy private key
echo <key> | semgrep-network-broker pubkey → copy public key
Go to Semgrep UI → paste public key → note the peer IP
Convert org ID to hex, hand-write config.yaml with IPv6 address
Hope it works, debug via logs if it doesn't
```

### After (1 command)
```bash
semgrep-network-broker setup --token <TOKEN> -d 12345
# → generates keys, registers, writes config, tests connectivity
```

## New files
- `cmd/setup.go` — setup CLI command
- `cmd/test.go` — test CLI command
- `pkg/setup.go` — backend API helpers (key generation, registration, config building)
- `pkg/setup_test.go` — unit tests for setup helpers
- `pkg/connectivity.go` — shared connectivity testing logic
- `pkg/connectivity_test.go` — unit tests for connectivity helpers

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All 24 unit tests pass (`go test ./pkg/... -v`)
- [ ] Manual test with real deployment ID and token
- [ ] Verify generated config.yaml is loadable by `semgrep-network-broker -c config.yaml`
