### PR TITLE
feat(github): add patch app/hook/confg to support github webhook rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Adding a `github` field to the config implicitly adds these endpoints to the all
 - POST `https://github.example.com/api/v3/repos/:owner/:repo/statuses/:commit`
 - PUT `https://github.example.com/api/v3/repos/:org/:repo/actions/secrets/SEMGREP_APP_TOKEN`
 - PUT `https://github.example.com/api/v3/repos/:owner/:repo/contents/.github/workflows/semgrep.yml`
+- PATCH `https://github.example.com/api/v3/app/hook/config`
 - PATCH `https://github.example.com/api/v3/orgs/:org/hooks/:hook_id`
 - PATCH `https://github.example.com/api/v3/repos/:owner/:repo/check-runs/:check_run_id`
 - PATCH `https://github.example.com/api/v3/repos/:owner/:repo/pulls/:number/comments/:comment_id`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -597,7 +597,7 @@ func PopulateAllowLists(config *Config) error {
 			},
 			AllowlistItem{
 				URL:               gitHubBaseUrl.JoinPath("/app/hook/config").String(),
-				Methods:           ParseHttpMethods([]string{"GET"}),
+				Methods:           ParseHttpMethods([]string{"GET", "PATCH"}),
 				SetRequestHeaders: headers,
 			},
 			AllowlistItem{


### PR DESCRIPTION
Update the network broker to add the new API endpoint required for https://github.com/semgrep/semgrep-app/pull/27873