### PR TITLE
fix(logs): mask sensitive headers in opt-in request logging

### DIFF
--- a/pkg/inbound_proxy.go
+++ b/pkg/inbound_proxy.go
@@ -97,7 +97,7 @@ func (config *InboundProxyConfig) Start(tnet *netstack.Net) error {
 		}
 
 		if config.Logging.LogRequestHeaders || allowlistMatch.LogRequestHeaders {
-			reqLogger = reqLogger.WithField("request_headers", c.Request.Header)
+			reqLogger = reqLogger.WithField("request_headers", RedactSensitiveHeaders(c.Request.Header))
 		}
 
 		reqLogger.Info("proxy.request")

--- a/pkg/logger.go
+++ b/pkg/logger.go
@@ -2,6 +2,8 @@ package pkg
 
 import (
 	"fmt"
+	"net/http"
+	"net/textproto"
 	"sync/atomic"
 	"time"
 
@@ -9,6 +11,26 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 )
+
+var sensitiveHeaders = map[string]struct{}{
+	"Authorization":       {},
+	"Proxy-Authorization": {},
+	"Private-Token":       {},
+}
+
+// RedactSensitiveHeaders returns a copy of h with sensitive header values masked,
+// leaving the original (which is still forwarded upstream) untouched.
+func RedactSensitiveHeaders(h http.Header) http.Header {
+	redacted := make(http.Header, len(h))
+	for name, values := range h {
+		if _, ok := sensitiveHeaders[textproto.CanonicalMIMEHeaderKey(name)]; ok {
+			redacted[name] = []string{RedactedString}
+		} else {
+			redacted[name] = values
+		}
+	}
+	return redacted
+}
 
 func GetRequestFields(c *gin.Context) log.Fields {
 	if fields, ok := c.Value("fields").(log.Fields); ok {

--- a/pkg/logger_test.go
+++ b/pkg/logger_test.go
@@ -1,0 +1,36 @@
+package pkg
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestRedactSensitiveHeaders(t *testing.T) {
+	original := http.Header{
+		"Authorization":       {"Bearer ghp_secret"},
+		"Proxy-Authorization": {"Basic abc123"},
+		"Private-Token":       {"glpat-secret"},
+		"authorization":       {"Bearer lowercase_secret"},
+		"Accept":              {"application/json"},
+		"X-Request-Id":        {"req-123"},
+	}
+
+	redacted := RedactSensitiveHeaders(original)
+
+	for _, name := range []string{"Authorization", "Proxy-Authorization", "Private-Token", "authorization"} {
+		if got := redacted[name]; len(got) != 1 || got[0] != RedactedString {
+			t.Errorf("header %q = %v, want [%s]", name, got, RedactedString)
+		}
+	}
+
+	passthrough := map[string]string{"Accept": "application/json", "X-Request-Id": "req-123"}
+	for name, want := range passthrough {
+		if got := redacted[name]; len(got) != 1 || got[0] != want {
+			t.Errorf("header %q = %v, want [%s]", name, got, want)
+		}
+	}
+
+	if got := original["Authorization"]; len(got) != 1 || got[0] != "Bearer ghp_secret" {
+		t.Errorf("original header map was mutated: Authorization = %v", got)
+	}
+}

--- a/pkg/relay.go
+++ b/pkg/relay.go
@@ -162,7 +162,7 @@ func (config *OutboundProxyConfig) Start() error {
 		}
 
 		if config.Logging.LogRequestHeaders {
-			logger = logger.WithField("request_headers", c.Request.Header)
+			logger = logger.WithField("request_headers", RedactSensitiveHeaders(c.Request.Header))
 		}
 
 		if !match {


### PR DESCRIPTION
Customers have the option to enable request header logging for debugging via `logRequestHeaders`. When enabled, we should avoid logging sensitive header values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)