### PR TITLE
feat(wireguard): optional broker-side WireGuard-over-TCP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ By default the broker reaches the Semgrep gateway over WireGuard's standard UDP 
 
 Leave `preferTcpTransport` unset (or `false`) to keep the default UDP behavior.
 
+> [!NOTE]
+> Prefer the default UDP transport whenever possible. Tunneling WireGuard over TCP means a reliable transport (TCP) carries traffic that is itself often reliable (e.g. the broker's own HTTPS requests), which can lead to [TCP meltdown](https://en.wikipedia.org/wiki/Network_congestion#TCP_meltdown_problem): when the network degrades, the two TCP layers' retransmission and backoff timers fight each other, and throughput and latency can get noticeably worse than they would over UDP. Enable `preferTcpTransport` only when outbound UDP is genuinely unavailable.
+
 Example:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ inbound:
   allowlist: [...]
 ```
 
+### WireGuard over TCP
+
+By default the broker reaches the Semgrep gateway over WireGuard's standard UDP transport. In networks where outbound UDP is blocked but outbound TCP is allowed, you can tunnel WireGuard over TCP by setting `inbound.wireguard.tcpTransportPort` to the gateway's TCP listener port. The broker then dials the gateway over TCP (reusing the peer endpoint's host) and encapsulates each WireGuard datagram as a 2-byte big-endian length prefix followed by the payload. The broker reconnects automatically with bounded backoff if the connection drops.
+
+Leave `tcpTransportPort` unset (or `0`) to keep the default UDP behavior.
+
+Example:
+
+```yaml
+inbound:
+  wireguard:
+    localAddress: ...
+    privateKey: ...
+    peers:
+      - endpoint: ... # the host here is reused for the TCP connection
+    tcpTransportPort: 51821 # connect to the gateway's TCP listener instead of UDP
+```
+
 ### HttpClient
 
 The `httpClient` configuration section modifies the HTTP client used for proxying requests.

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ inbound:
 
 ### WireGuard over TCP
 
-By default the broker reaches the Semgrep gateway over WireGuard's standard UDP transport. In networks where outbound UDP is blocked but outbound TCP is allowed, you can tunnel WireGuard over TCP by setting `inbound.wireguard.tcpTransportPort` to the gateway's TCP listener port. The broker then dials the gateway over TCP (reusing the peer endpoint's host) and encapsulates each WireGuard datagram as a 2-byte big-endian length prefix followed by the payload. The broker reconnects automatically with bounded backoff if the connection drops.
+By default the broker reaches the Semgrep gateway over WireGuard's standard UDP transport. In networks where outbound UDP is blocked but outbound TCP is allowed, you can tunnel WireGuard over TCP by setting `inbound.wireguard.preferTcpTransport: true`. The broker then dials the gateway over TCP at the same host:port as the peer endpoint and encapsulates each WireGuard datagram as a 2-byte big-endian length prefix followed by the payload. The broker reconnects automatically with bounded backoff if the connection drops.
 
-Leave `tcpTransportPort` unset (or `0`) to keep the default UDP behavior.
+Leave `preferTcpTransport` unset (or `false`) to keep the default UDP behavior.
 
 Example:
 
@@ -75,8 +75,8 @@ inbound:
     localAddress: ...
     privateKey: ...
     peers:
-      - endpoint: ... # the host here is reused for the TCP connection
-    tcpTransportPort: 51821 # connect to the gateway's TCP listener instead of UDP
+      - endpoint: ... # the broker connects to this host:port over TCP instead of UDP
+    preferTcpTransport: true
 ```
 
 ### HttpClient

--- a/it/e2e_tcp_test.go
+++ b/it/e2e_tcp_test.go
@@ -1,0 +1,230 @@
+package it
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mcuadros/go-defaults"
+	"github.com/semgrep/semgrep-network-broker/cmd"
+	"github.com/semgrep/semgrep-network-broker/pkg"
+
+	log "github.com/sirupsen/logrus"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+// startTcpToUdpShim stands in for the gateway's TCP WireGuard listener. It
+// accepts framed TCP connections from the broker, decapsulates them into UDP
+// datagrams aimed at the real (UDP) WireGuard gateway, and re-frames the UDP
+// replies back over the same TCP connection. This mirrors the gateway-side
+// encapsulation in semgrep-private-link PR #86 and proves the broker's TCP
+// transport interoperates with a genuine WireGuard device.
+func startTcpToUdpShim(t *testing.T, udpTarget string) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start tcp shim: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			tcpConn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go bridgeTcpToUdp(tcpConn, udpTarget)
+		}
+	}()
+
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func bridgeTcpToUdp(tcpConn net.Conn, udpTarget string) {
+	defer tcpConn.Close()
+
+	raddr, err := net.ResolveUDPAddr("udp", udpTarget)
+	if err != nil {
+		return
+	}
+	udpConn, err := net.DialUDP("udp", nil, raddr)
+	if err != nil {
+		return
+	}
+	defer udpConn.Close()
+
+	// UDP replies from the gateway -> framed TCP back to the broker
+	go func() {
+		buf := make([]byte, 65535)
+		for {
+			n, err := udpConn.Read(buf)
+			if err != nil {
+				tcpConn.Close()
+				return
+			}
+			var header [2]byte
+			binary.BigEndian.PutUint16(header[:], uint16(n))
+			if _, err := tcpConn.Write(append(header[:], buf[:n]...)); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Framed TCP from the broker -> UDP datagrams to the gateway
+	for {
+		var header [2]byte
+		if _, err := io.ReadFull(tcpConn, header[:]); err != nil {
+			return
+		}
+		length := binary.BigEndian.Uint16(header[:])
+		if length == 0 {
+			continue
+		}
+		payload := make([]byte, length)
+		if _, err := io.ReadFull(tcpConn, payload); err != nil {
+			return
+		}
+		if _, err := udpConn.Write(payload); err != nil {
+			return
+		}
+	}
+}
+
+func TestWireguardInboundProxyOverTcp(t *testing.T) {
+	gatewayWireguardPort := mustGetFreePort()
+	gatewayWireguardAddress := mustGetRandomPrivateAddress()
+	gatewayPrivateKey, err := wgtypes.GeneratePrivateKey()
+	if err != nil {
+		panic(err)
+	}
+	gatewayPublicKey := gatewayPrivateKey.PublicKey()
+
+	clientPrivateKey, _ := wgtypes.GeneratePrivateKey()
+	clientPublicKey := clientPrivateKey.PublicKey()
+	clientWireguardAddress := mustGetRandomPrivateAddress()
+
+	// setup "remote" wireguard peer (the gateway), speaking plain UDP
+	remoteWireguardConfig := &pkg.WireguardBase{
+		LocalAddress: gatewayWireguardAddress.String(),
+		PrivateKey:   gatewayPrivateKey[:],
+		Peers: []pkg.WireguardPeer{
+			{
+				PublicKey:                  clientPublicKey[:],
+				AllowedIps:                 fmt.Sprintf("%v/128", clientWireguardAddress),
+				DisablePersistentKeepalive: true,
+			},
+		},
+		ListenPort: gatewayWireguardPort,
+	}
+	defaults.SetDefaults(remoteWireguardConfig)
+
+	remoteWireguard, remoteWireguardTeardown, err := remoteWireguardConfig.Start()
+	if err != nil {
+		t.Errorf("failed to setup remote wireguard: %v", err)
+	}
+	defer remoteWireguardTeardown()
+	log.Info("Remote wireguard peer is up")
+
+	// stand up the TCP->UDP shim in front of the gateway's UDP listener
+	shimTcpPort := startTcpToUdpShim(t, fmt.Sprintf("127.0.0.1:%d", gatewayWireguardPort))
+	log.WithField("tcp_port", shimTcpPort).Info("TCP shim is up")
+
+	// set up internal service (the thing that the broker proxies to)
+	internalServer := gin.Default()
+	internalServer.UseRawPath = true
+	internalServer.UnescapePathValues = false
+	internalServer.Any("/allowed-get", func(ctx *gin.Context) {
+		ctx.String(200, "Hello")
+	})
+
+	internalListener, err := net.Listen("tcp", "127.0.0.1:")
+	if err != nil {
+		t.Errorf("Failed to start internal listener: %v", err)
+	}
+	defer internalListener.Close()
+	go internalServer.RunListener(internalListener)
+	log.Info("Internal server is up")
+
+	internalServerBaseUrl := fmt.Sprintf("http://%v", internalListener.Addr().String())
+
+	// start network broker with TCP transport enabled. The peer endpoint host
+	// (127.0.0.1) is reused; TcpTransportPort points at the shim.
+	brokerConfig := &pkg.Config{
+		Inbound: pkg.InboundProxyConfig{
+			Wireguard: pkg.WireguardBase{
+				LocalAddress: clientWireguardAddress.String(),
+				PrivateKey:   clientPrivateKey[:],
+				Peers: []pkg.WireguardPeer{
+					{
+						PublicKey:  gatewayPublicKey[:],
+						AllowedIps: fmt.Sprintf("%v/128", gatewayWireguardAddress),
+						Endpoint:   fmt.Sprintf("127.0.0.1:%v", gatewayWireguardPort),
+					},
+				},
+				TcpTransportPort: shimTcpPort,
+			},
+			Allowlist: []pkg.AllowlistItem{
+				{
+					URL:     internalServerBaseUrl + "/allowed-get",
+					Methods: pkg.ParseHttpMethods([]string{"GET"}),
+				},
+			},
+			Heartbeat: pkg.HeartbeatConfig{
+				URL: fmt.Sprintf("http://[%v]/ping", gatewayWireguardAddress),
+			},
+		},
+	}
+	defaults.SetDefaults(brokerConfig)
+
+	teardown, err := cmd.StartNetworkBroker(brokerConfig)
+	if err != nil {
+		log.Error(err)
+	}
+	defer teardown()
+	log.Info("Network broker is up (TCP transport)")
+
+	// set up "remote" HTTP client that dials through the gateway wireguard
+	remoteHttpClient := testClient{
+		Client: &http.Client{
+			Transport: &http.Transport{
+				DialContext: remoteWireguard.DialContext,
+			},
+			Timeout: 5 * time.Second,
+		},
+		PeerAddress: clientWireguardAddress,
+	}
+
+	// The tunnel comes up only once the broker's persistent keepalive triggers a
+	// handshake over TCP, so retry until the proxied request succeeds.
+	assertEventually(t, 15*time.Second, func() bool {
+		url := fmt.Sprintf("http://[%v]/proxy/%v/allowed-get", clientWireguardAddress, internalServerBaseUrl)
+		statusCode, _, err := remoteHttpClient.Request(mustGetRequest(t, "GET", url))
+		return err == nil && statusCode == 200
+	})
+}
+
+func mustGetRequest(t *testing.T, method string, rawUrl string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, rawUrl, nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	return req
+}
+
+func assertEventually(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatal("condition not met within timeout")
+}

--- a/it/e2e_tcp_test.go
+++ b/it/e2e_tcp_test.go
@@ -24,9 +24,13 @@ import (
 // replies back over the same TCP connection. This mirrors the gateway-side
 // encapsulation in semgrep-private-link PR #86 and proves the broker's TCP
 // transport interoperates with a genuine WireGuard device.
-func startTcpToUdpShim(t *testing.T, udpTarget string) int {
+//
+// It listens for TCP on tcpListenAddr, which is the same host:port the gateway
+// uses for UDP (TCP and UDP port namespaces are independent), matching the
+// broker's preferTcpTransport behavior of reusing the peer endpoint address.
+func startTcpToUdpShim(t *testing.T, tcpListenAddr string, udpTarget string) {
 	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", tcpListenAddr)
 	if err != nil {
 		t.Fatalf("failed to start tcp shim: %v", err)
 	}
@@ -41,8 +45,6 @@ func startTcpToUdpShim(t *testing.T, udpTarget string) int {
 			go bridgeTcpToUdp(tcpConn, udpTarget)
 		}
 	}()
-
-	return ln.Addr().(*net.TCPAddr).Port
 }
 
 func bridgeTcpToUdp(tcpConn net.Conn, udpTarget string) {
@@ -130,9 +132,11 @@ func TestWireguardInboundProxyOverTcp(t *testing.T) {
 	defer remoteWireguardTeardown()
 	log.Info("Remote wireguard peer is up")
 
-	// stand up the TCP->UDP shim in front of the gateway's UDP listener
-	shimTcpPort := startTcpToUdpShim(t, fmt.Sprintf("127.0.0.1:%d", gatewayWireguardPort))
-	log.WithField("tcp_port", shimTcpPort).Info("TCP shim is up")
+	// stand up the TCP->UDP shim in front of the gateway's UDP listener, on the
+	// same port number (the broker reuses the peer endpoint host:port for TCP)
+	gatewayAddr := fmt.Sprintf("127.0.0.1:%d", gatewayWireguardPort)
+	startTcpToUdpShim(t, gatewayAddr, gatewayAddr)
+	log.WithField("addr", gatewayAddr).Info("TCP shim is up")
 
 	// set up internal service (the thing that the broker proxies to)
 	internalServer := gin.Default()
@@ -152,8 +156,8 @@ func TestWireguardInboundProxyOverTcp(t *testing.T) {
 
 	internalServerBaseUrl := fmt.Sprintf("http://%v", internalListener.Addr().String())
 
-	// start network broker with TCP transport enabled. The peer endpoint host
-	// (127.0.0.1) is reused; TcpTransportPort points at the shim.
+	// start network broker with TCP transport enabled. The peer endpoint
+	// host:port (127.0.0.1:gatewayWireguardPort) is reused for the TCP dial.
 	brokerConfig := &pkg.Config{
 		Inbound: pkg.InboundProxyConfig{
 			Wireguard: pkg.WireguardBase{
@@ -166,7 +170,7 @@ func TestWireguardInboundProxyOverTcp(t *testing.T) {
 						Endpoint:   fmt.Sprintf("127.0.0.1:%v", gatewayWireguardPort),
 					},
 				},
-				TcpTransportPort: shimTcpPort,
+				PreferTcpTransport: true,
 			},
 			Allowlist: []pkg.AllowlistItem{
 				{

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -96,6 +96,12 @@ type WireguardBase struct {
 	Peers                        []WireguardPeer       `mapstructure:"peers" json:"peers" validate:"empty=false"`
 	Verbose                      bool                  `mapstructure:"verbose" json:"verbose"`
 	DisablePeerSettingsDnsLookup bool                  `mapstructure:"disablePeerSettingsDnsLookup" json:"disablePeerSettingsDnsLookup"`
+	// TcpTransportPort, when greater than zero, enables WireGuard-over-TCP
+	// encapsulation: instead of the default UDP transport, the broker dials the
+	// gateway's TCP listener on this port (reusing the peer endpoint's host).
+	// This supports customer networks where outbound TCP is allowed but UDP is
+	// blocked. Leave unset (0) to preserve the default UDP behavior.
+	TcpTransportPort int `mapstructure:"tcpTransportPort" json:"tcpTransportPort" validate:"gte=0"`
 }
 
 type BitTester interface {

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -96,12 +96,12 @@ type WireguardBase struct {
 	Peers                        []WireguardPeer       `mapstructure:"peers" json:"peers" validate:"empty=false"`
 	Verbose                      bool                  `mapstructure:"verbose" json:"verbose"`
 	DisablePeerSettingsDnsLookup bool                  `mapstructure:"disablePeerSettingsDnsLookup" json:"disablePeerSettingsDnsLookup"`
-	// TcpTransportPort, when greater than zero, enables WireGuard-over-TCP
-	// encapsulation: instead of the default UDP transport, the broker dials the
-	// gateway's TCP listener on this port (reusing the peer endpoint's host).
-	// This supports customer networks where outbound TCP is allowed but UDP is
-	// blocked. Leave unset (0) to preserve the default UDP behavior.
-	TcpTransportPort int `mapstructure:"tcpTransportPort" json:"tcpTransportPort" validate:"gte=0"`
+	// PreferTcpTransport, when true, enables WireGuard-over-TCP encapsulation:
+	// instead of the default UDP transport, the broker dials the gateway over TCP
+	// at the same host:port as the peer endpoint. This supports customer networks
+	// where outbound TCP is allowed but UDP is blocked. Leave false to preserve
+	// the default UDP behavior.
+	PreferTcpTransport bool `mapstructure:"preferTcpTransport" json:"preferTcpTransport"`
 }
 
 type BitTester interface {

--- a/pkg/wireguard.go
+++ b/pkg/wireguard.go
@@ -84,6 +84,24 @@ func (base *WireguardBase) ResolvePeerEndpoints() error {
 	return nil
 }
 
+// newBind selects the WireGuard transport. By default it returns the standard
+// UDP bind; when TcpTransportPort is set it returns a bind that encapsulates
+// WireGuard over an outbound TCP connection to the gateway. Peer endpoints must
+// already be resolved (see ResolvePeerEndpoints) before calling this.
+func (config *WireguardBase) newBind() (conn.Bind, error) {
+	if config.TcpTransportPort <= 0 {
+		return conn.NewDefaultBind(), nil
+	}
+
+	address, err := config.tcpTransportAddress()
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure wireguard tcp transport: %w", err)
+	}
+
+	log.WithField("wireguard_tcp_address", address).Info("wireguard.tcp_transport_enabled")
+	return NewWireguardTcpBind(address, nil), nil
+}
+
 func (config *WireguardBase) Start() (*netstack.Net, func() error, error) {
 	// ensure config is valid
 	if err := validate.Validate(config); err != nil {
@@ -121,8 +139,14 @@ func (config *WireguardBase) Start() (*netstack.Net, func() error, error) {
 		return nil, nil, fmt.Errorf("failed to create wireguard tun: %v", err)
 	}
 
+	// select the transport: TCP encapsulation if configured, otherwise default UDP
+	bind, err := config.newBind()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	// create wireguard device
-	dev := device.NewDevice(tun, conn.NewDefaultBind(), newLoggerBridge(config.Verbose))
+	dev := device.NewDevice(tun, bind, newLoggerBridge(config.Verbose))
 
 	// apply wireguard configs
 	if err := dev.IpcSet(config.GenerateConfig()); err != nil {

--- a/pkg/wireguard.go
+++ b/pkg/wireguard.go
@@ -89,7 +89,7 @@ func (base *WireguardBase) ResolvePeerEndpoints() error {
 // WireGuard over an outbound TCP connection to the gateway. Peer endpoints must
 // already be resolved (see ResolvePeerEndpoints) before calling this.
 func (config *WireguardBase) newBind() (conn.Bind, error) {
-	if config.TcpTransportPort <= 0 {
+	if !config.PreferTcpTransport {
 		return conn.NewDefaultBind(), nil
 	}
 

--- a/pkg/wireguard_tcp.go
+++ b/pkg/wireguard_tcp.go
@@ -1,0 +1,383 @@
+package pkg
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.zx2c4.com/wireguard/conn"
+)
+
+// This file implements WireGuard-over-TCP encapsulation for the broker. It is
+// kept deliberately separate from the default UDP path (which continues to use
+// conn.NewDefaultBind()) so the common case stays easy to reason about.
+//
+// The wire format matches the gateway's TCP WireGuard listener: each WireGuard
+// datagram is sent as a uint16 big-endian payload length followed by that many
+// payload bytes. The broker dials the gateway's TCP listener, frames every
+// outbound datagram, and decapsulates inbound frames back into the WireGuard
+// receive path.
+
+const (
+	// tcpMaxFramePayload is the largest WireGuard datagram we can encapsulate in a
+	// single length-prefixed frame. The 2-byte big-endian length prefix caps this
+	// at 65535 bytes.
+	tcpMaxFramePayload = 65535
+
+	tcpDialTimeout         = 10 * time.Second
+	tcpReconnectMinBackoff = 500 * time.Millisecond
+	tcpReconnectMaxBackoff = 30 * time.Second
+
+	// tcpRecvQueueSize bounds the number of decapsulated payloads buffered between
+	// the TCP read loop and WireGuard's receive func.
+	tcpRecvQueueSize = 128
+)
+
+var errFrameTooLarge = fmt.Errorf("wireguard tcp frame payload exceeds %d bytes", tcpMaxFramePayload)
+var errTcpBindNotConnected = fmt.Errorf("wireguard tcp transport is not connected")
+
+// writeFrame encapsulates a single WireGuard datagram as a 2-byte big-endian
+// length prefix followed by the payload bytes. The frame is written with a
+// single Write call so a partial failure cannot split a length prefix from its
+// payload on the wire.
+func writeFrame(w io.Writer, payload []byte) error {
+	if len(payload) > tcpMaxFramePayload {
+		return errFrameTooLarge
+	}
+	frame := make([]byte, 2+len(payload))
+	binary.BigEndian.PutUint16(frame[:2], uint16(len(payload)))
+	copy(frame[2:], payload)
+	_, err := w.Write(frame)
+	return err
+}
+
+// readFrame reads a single length-prefixed frame (written by writeFrame or the
+// gateway) and returns the decapsulated payload. A zero-length frame returns a
+// nil payload, which callers may ignore.
+func readFrame(r io.Reader) ([]byte, error) {
+	var header [2]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return nil, err
+	}
+	length := binary.BigEndian.Uint16(header[:])
+	if length == 0 {
+		return nil, nil
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+// tcpEndpoint identifies the gateway peer for the TCP transport. WireGuard
+// treats the endpoint as opaque routing metadata; since the TCP bind manages a
+// single connection to the gateway, only one endpoint is ever in play.
+type tcpEndpoint struct {
+	addr netip.AddrPort
+}
+
+var _ conn.Endpoint = (*tcpEndpoint)(nil)
+
+func (e *tcpEndpoint) ClearSrc()           {}
+func (e *tcpEndpoint) SrcToString() string { return "" }
+func (e *tcpEndpoint) DstToString() string { return e.addr.String() }
+func (e *tcpEndpoint) DstToBytes() []byte {
+	b, _ := e.addr.MarshalBinary()
+	return b
+}
+func (e *tcpEndpoint) DstIP() netip.Addr { return e.addr.Addr() }
+func (e *tcpEndpoint) SrcIP() netip.Addr { return netip.Addr{} }
+
+// wireguardTcpBind is a conn.Bind that tunnels WireGuard packets over a single
+// outbound TCP connection to the gateway, reconnecting with bounded backoff on
+// failure. It is used in place of conn.NewDefaultBind() when TCP transport is
+// enabled.
+type wireguardTcpBind struct {
+	address  string
+	endpoint atomic.Pointer[tcpEndpoint]
+	logger   *log.Entry
+
+	mu     sync.Mutex
+	conn   net.Conn // current connection; nil while (re)connecting
+	open   bool
+	closed bool
+
+	recvCh  chan []byte
+	closeCh chan struct{}
+	wg      sync.WaitGroup
+}
+
+var _ conn.Bind = (*wireguardTcpBind)(nil)
+
+// NewWireguardTcpBind returns a conn.Bind that encapsulates WireGuard traffic
+// over an outbound TCP connection to address (host:port of the gateway's TCP
+// listener).
+func NewWireguardTcpBind(address string, logger *log.Entry) *wireguardTcpBind {
+	if logger == nil {
+		logger = log.NewEntry(log.StandardLogger())
+	}
+	b := &wireguardTcpBind{
+		address: address,
+		logger:  logger.WithField("wireguard_tcp_address", address),
+	}
+	// Seed the endpoint from the dial address so the receive path has something
+	// to report even before WireGuard parses the configured endpoint.
+	if addr, err := netip.ParseAddrPort(address); err == nil {
+		b.endpoint.Store(&tcpEndpoint{addr: addr})
+	}
+	return b
+}
+
+func (b *wireguardTcpBind) Open(port uint16) ([]conn.ReceiveFunc, uint16, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.open {
+		return nil, 0, conn.ErrBindAlreadyOpen
+	}
+	b.open = true
+	b.closed = false
+	b.recvCh = make(chan []byte, tcpRecvQueueSize)
+	b.closeCh = make(chan struct{})
+
+	b.wg.Add(1)
+	go b.manage()
+
+	return []conn.ReceiveFunc{b.receive}, port, nil
+}
+
+func (b *wireguardTcpBind) Close() error {
+	b.mu.Lock()
+	if !b.open || b.closed {
+		b.mu.Unlock()
+		return nil
+	}
+	b.closed = true
+	close(b.closeCh)
+	c := b.conn
+	b.conn = nil
+	b.mu.Unlock()
+
+	if c != nil {
+		c.Close()
+	}
+
+	// Wait for the manager (and its read loop) to exit so we don't leak
+	// goroutines or sockets across reopen.
+	b.wg.Wait()
+
+	b.mu.Lock()
+	b.open = false
+	b.mu.Unlock()
+	return nil
+}
+
+func (b *wireguardTcpBind) SetMark(mark uint32) error { return nil }
+
+func (b *wireguardTcpBind) BatchSize() int { return 1 }
+
+func (b *wireguardTcpBind) ParseEndpoint(s string) (conn.Endpoint, error) {
+	addr, err := netip.ParseAddrPort(s)
+	if err != nil {
+		return nil, err
+	}
+	ep := &tcpEndpoint{addr: addr}
+	b.endpoint.Store(ep)
+	return ep, nil
+}
+
+// Send frames every datagram in bufs and writes it to the current TCP
+// connection. Writes are serialized under b.mu so concurrent WireGuard sends
+// cannot interleave frames. A write failure tears down the connection so the
+// manager goroutine reconnects.
+func (b *wireguardTcpBind) Send(bufs [][]byte, ep conn.Endpoint) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return net.ErrClosed
+	}
+	c := b.conn
+	if c == nil {
+		// Not connected yet. Drop the datagram; WireGuard will retransmit
+		// handshakes/keepalives once the connection is (re)established.
+		return errTcpBindNotConnected
+	}
+
+	for _, buf := range bufs {
+		if len(buf) == 0 {
+			continue
+		}
+		if err := writeFrame(c, buf); err != nil {
+			// Tear down this connection so the manager dials a fresh one.
+			c.Close()
+			if b.conn == c {
+				b.conn = nil
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// receive is the single conn.ReceiveFunc handed to WireGuard. It delivers
+// decapsulated payloads produced by the read loop.
+func (b *wireguardTcpBind) receive(bufs [][]byte, sizes []int, eps []conn.Endpoint) (int, error) {
+	// Prefer reporting closure over draining buffered payloads.
+	select {
+	case <-b.closeCh:
+		return 0, net.ErrClosed
+	default:
+	}
+
+	select {
+	case <-b.closeCh:
+		return 0, net.ErrClosed
+	case payload := <-b.recvCh:
+		sizes[0] = copy(bufs[0], payload)
+		if ep := b.endpoint.Load(); ep != nil {
+			eps[0] = ep
+		}
+		return 1, nil
+	}
+}
+
+// manage owns the lifecycle of the outbound TCP connection: dial, run the read
+// loop, and reconnect with bounded backoff. Exactly one of these runs per Open.
+func (b *wireguardTcpBind) manage() {
+	defer b.wg.Done()
+
+	backoff := tcpReconnectMinBackoff
+	for {
+		if b.isClosed() {
+			return
+		}
+
+		c, err := net.DialTimeout("tcp", b.address, tcpDialTimeout)
+		if err != nil {
+			b.logger.WithError(err).Warn("wireguard_tcp.dial_failed")
+			if !b.sleep(backoff) {
+				return
+			}
+			backoff = nextBackoff(backoff)
+			continue
+		}
+
+		b.logger.Info("wireguard_tcp.connected")
+		// Reset backoff after a successful connection so a single drop reconnects
+		// promptly, but a flapping gateway still backs off.
+		backoff = tcpReconnectMinBackoff
+		b.setConn(c)
+
+		// Block reading frames until the connection fails or is closed.
+		b.readLoop(c)
+		b.clearConn(c)
+
+		if b.isClosed() {
+			return
+		}
+		if !b.sleep(backoff) {
+			return
+		}
+		backoff = nextBackoff(backoff)
+	}
+}
+
+// readLoop decapsulates frames from c and forwards payloads to the receive func.
+// It returns when the connection fails, is closed, or the bind is closing.
+func (b *wireguardTcpBind) readLoop(c net.Conn) {
+	for {
+		payload, err := readFrame(c)
+		if err != nil {
+			if !b.isClosed() {
+				b.logger.WithError(err).Warn("wireguard_tcp.read_failed")
+			}
+			return
+		}
+		if len(payload) == 0 {
+			continue // ignore empty frames
+		}
+		select {
+		case b.recvCh <- payload:
+		case <-b.closeCh:
+			return
+		}
+	}
+}
+
+func (b *wireguardTcpBind) setConn(c net.Conn) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		c.Close()
+		return
+	}
+	b.conn = c
+}
+
+func (b *wireguardTcpBind) clearConn(c net.Conn) {
+	b.mu.Lock()
+	if b.conn == c {
+		b.conn = nil
+	}
+	b.mu.Unlock()
+	c.Close()
+}
+
+func (b *wireguardTcpBind) isClosed() bool {
+	select {
+	case <-b.closeCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// sleep waits for d, returning false early if the bind is closed.
+func (b *wireguardTcpBind) sleep(d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-b.closeCh:
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+func nextBackoff(d time.Duration) time.Duration {
+	next := d * 2
+	if next > tcpReconnectMaxBackoff {
+		return tcpReconnectMaxBackoff
+	}
+	return next
+}
+
+// tcpTransportAddress derives the gateway's TCP listener address (host:port)
+// from the configured TCP transport port and the first WireGuard peer that has
+// an endpoint. The host is reused from the peer's resolved endpoint.
+func (config *WireguardBase) tcpTransportAddress() (string, error) {
+	for i := range config.Peers {
+		endpoint := config.Peers[i].resolvedEndpoint
+		if endpoint == "" {
+			endpoint = config.Peers[i].Endpoint
+		}
+		if endpoint == "" {
+			continue
+		}
+		host, _, err := net.SplitHostPort(endpoint)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse wireguard peer endpoint %q: %w", endpoint, err)
+		}
+		return net.JoinHostPort(host, strconv.Itoa(config.TcpTransportPort)), nil
+	}
+	return "", fmt.Errorf("tcp transport enabled but no wireguard peer endpoint is configured")
+}

--- a/pkg/wireguard_tcp.go
+++ b/pkg/wireguard_tcp.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net"
 	"net/netip"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -361,23 +360,17 @@ func nextBackoff(d time.Duration) time.Duration {
 	return next
 }
 
-// tcpTransportAddress derives the gateway's TCP listener address (host:port)
-// from the configured TCP transport port and the first WireGuard peer that has
-// an endpoint. The host is reused from the peer's resolved endpoint.
+// tcpTransportAddress returns the gateway's TCP address (host:port) for the TCP
+// transport, reusing the first WireGuard peer endpoint as-is. The gateway listens
+// for TCP on the same host:port it uses for UDP.
 func (config *WireguardBase) tcpTransportAddress() (string, error) {
 	for i := range config.Peers {
-		endpoint := config.Peers[i].resolvedEndpoint
-		if endpoint == "" {
-			endpoint = config.Peers[i].Endpoint
+		if config.Peers[i].resolvedEndpoint != "" {
+			return config.Peers[i].resolvedEndpoint, nil
 		}
-		if endpoint == "" {
-			continue
+		if config.Peers[i].Endpoint != "" {
+			return config.Peers[i].Endpoint, nil
 		}
-		host, _, err := net.SplitHostPort(endpoint)
-		if err != nil {
-			return "", fmt.Errorf("failed to parse wireguard peer endpoint %q: %w", endpoint, err)
-		}
-		return net.JoinHostPort(host, strconv.Itoa(config.TcpTransportPort)), nil
 	}
 	return "", fmt.Errorf("tcp transport enabled but no wireguard peer endpoint is configured")
 }

--- a/pkg/wireguard_tcp_test.go
+++ b/pkg/wireguard_tcp_test.go
@@ -1,0 +1,287 @@
+package pkg
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.zx2c4.com/wireguard/conn"
+)
+
+func quietLogger() *log.Entry {
+	l := log.New()
+	l.SetOutput(io.Discard)
+	return log.NewEntry(l)
+}
+
+func TestWriteReadFrameRoundTrip(t *testing.T) {
+	cases := [][]byte{
+		[]byte("hello wireguard"),
+		{0x00},
+		bytes.Repeat([]byte{0xAB}, 1500),
+		bytes.Repeat([]byte{0xCD}, tcpMaxFramePayload),
+	}
+
+	for _, payload := range cases {
+		buf := &bytes.Buffer{}
+		if err := writeFrame(buf, payload); err != nil {
+			t.Fatalf("writeFrame(%d bytes) failed: %v", len(payload), err)
+		}
+
+		// a frame is exactly 2 length bytes + the payload
+		if buf.Len() != 2+len(payload) {
+			t.Fatalf("expected framed length %d, got %d", 2+len(payload), buf.Len())
+		}
+
+		got, err := readFrame(buf)
+		if err != nil {
+			t.Fatalf("readFrame failed: %v", err)
+		}
+		if !bytes.Equal(got, payload) {
+			t.Fatalf("round trip mismatch: got %d bytes, want %d bytes", len(got), len(payload))
+		}
+	}
+}
+
+func TestWriteFrameRejectsOversizedPayload(t *testing.T) {
+	payload := bytes.Repeat([]byte{0x01}, tcpMaxFramePayload+1)
+	buf := &bytes.Buffer{}
+
+	err := writeFrame(buf, payload)
+	if !errors.Is(err, errFrameTooLarge) {
+		t.Fatalf("expected errFrameTooLarge, got %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("oversized frame should not write any bytes, wrote %d", buf.Len())
+	}
+}
+
+func TestReadFrameEmptyPayload(t *testing.T) {
+	buf := &bytes.Buffer{}
+	if err := writeFrame(buf, nil); err != nil {
+		t.Fatalf("writeFrame(nil) failed: %v", err)
+	}
+	got, err := readFrame(buf)
+	if err != nil {
+		t.Fatalf("readFrame failed: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil payload for empty frame, got %d bytes", len(got))
+	}
+}
+
+// fakeGateway is a minimal TCP server that stands in for the gateway's TCP
+// WireGuard listener. It hands accepted connections back to the test.
+type fakeGateway struct {
+	ln    net.Listener
+	conns chan net.Conn
+}
+
+func startFakeGateway(t *testing.T) *fakeGateway {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start fake gateway: %v", err)
+	}
+	g := &fakeGateway{ln: ln, conns: make(chan net.Conn, 4)}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			g.conns <- c
+		}
+	}()
+	t.Cleanup(func() { ln.Close() })
+	return g
+}
+
+func (g *fakeGateway) address() string { return g.ln.Addr().String() }
+
+func (g *fakeGateway) accept(t *testing.T) net.Conn {
+	t.Helper()
+	select {
+	case c := <-g.conns:
+		return c
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for broker to connect over TCP")
+		return nil
+	}
+}
+
+// sendUntilConnected retries Send until the bind has an established connection,
+// tolerating the brief window between dial and connection registration. Exactly
+// one frame is written (failed attempts before connection write nothing).
+func sendUntilConnected(t *testing.T, b *wireguardTcpBind, payload []byte, ep conn.Endpoint) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		err := b.Send([][]byte{payload}, ep)
+		if err == nil {
+			return
+		}
+		if !errors.Is(err, errTcpBindNotConnected) {
+			t.Fatalf("unexpected Send error: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("broker never established TCP connection")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestWireguardTcpBindSendsFramedPackets(t *testing.T) {
+	gateway := startFakeGateway(t)
+
+	bind := NewWireguardTcpBind(gateway.address(), quietLogger())
+	if _, _, err := bind.Open(0); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer bind.Close()
+
+	ep, err := bind.ParseEndpoint(gateway.address())
+	if err != nil {
+		t.Fatalf("ParseEndpoint failed: %v", err)
+	}
+
+	gwConn := gateway.accept(t)
+	defer gwConn.Close()
+
+	payload := []byte("framed wireguard datagram")
+	sendUntilConnected(t, bind, payload, ep)
+
+	gwConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	got, err := readFrame(gwConn)
+	if err != nil {
+		t.Fatalf("gateway failed to read framed packet: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("gateway received %q, want %q", got, payload)
+	}
+}
+
+func TestWireguardTcpBindReceivesFramedPackets(t *testing.T) {
+	gateway := startFakeGateway(t)
+
+	bind := NewWireguardTcpBind(gateway.address(), quietLogger())
+	fns, _, err := bind.Open(0)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer bind.Close()
+
+	gwConn := gateway.accept(t)
+	defer gwConn.Close()
+
+	payload := []byte("inbound wireguard datagram")
+	if err := writeFrame(gwConn, payload); err != nil {
+		t.Fatalf("gateway failed to write framed packet: %v", err)
+	}
+
+	type recvResult struct {
+		n    int
+		size int
+		buf  []byte
+		err  error
+	}
+	resultCh := make(chan recvResult, 1)
+	go func() {
+		bufs := [][]byte{make([]byte, 2048)}
+		sizes := []int{0}
+		eps := []conn.Endpoint{nil}
+		n, err := fns[0](bufs, sizes, eps)
+		resultCh <- recvResult{n: n, size: sizes[0], buf: bufs[0], err: err}
+	}()
+
+	select {
+	case res := <-resultCh:
+		if res.err != nil {
+			t.Fatalf("receive func returned error: %v", res.err)
+		}
+		if res.n != 1 {
+			t.Fatalf("expected 1 packet, got %d", res.n)
+		}
+		if !bytes.Equal(res.buf[:res.size], payload) {
+			t.Fatalf("received %q, want %q", res.buf[:res.size], payload)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for decapsulated packet")
+	}
+}
+
+func TestWireguardTcpBindReconnects(t *testing.T) {
+	gateway := startFakeGateway(t)
+
+	bind := NewWireguardTcpBind(gateway.address(), quietLogger())
+	if _, _, err := bind.Open(0); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer bind.Close()
+
+	ep, err := bind.ParseEndpoint(gateway.address())
+	if err != nil {
+		t.Fatalf("ParseEndpoint failed: %v", err)
+	}
+
+	// first connection
+	conn1 := gateway.accept(t)
+	sendUntilConnected(t, bind, []byte("before drop"), ep)
+
+	// simulate the gateway dropping the connection
+	conn1.Close()
+
+	// the broker should dial a fresh connection with bounded backoff
+	conn2 := gateway.accept(t)
+	defer conn2.Close()
+
+	payload := []byte("after reconnect")
+	sendUntilConnected(t, bind, payload, ep)
+
+	conn2.SetReadDeadline(time.Now().Add(2 * time.Second))
+	got, err := readFrame(conn2)
+	if err != nil {
+		t.Fatalf("failed to read after reconnect: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("after reconnect received %q, want %q", got, payload)
+	}
+}
+
+func TestWireguardTcpBindCloseUnblocksReceive(t *testing.T) {
+	gateway := startFakeGateway(t)
+
+	bind := NewWireguardTcpBind(gateway.address(), quietLogger())
+	fns, _, err := bind.Open(0)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		bufs := [][]byte{make([]byte, 2048)}
+		sizes := []int{0}
+		eps := []conn.Endpoint{nil}
+		_, err := fns[0](bufs, sizes, eps)
+		errCh <- err
+	}()
+
+	// give the receive func a moment to block, then close
+	time.Sleep(20 * time.Millisecond)
+	if err := bind.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, net.ErrClosed) {
+			t.Fatalf("expected net.ErrClosed after Close, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("receive func did not return after Close")
+	}
+}


### PR DESCRIPTION
## Summary

Adds an opt-in **WireGuard-over-TCP** transport to the broker, the broker-side half of the gateway encapsulation in `semgrep-private-link` PR #86. This supports customer networks where outbound TCP is allowed but UDP is blocked.

- **Default behavior is unchanged** — without config the broker still uses the standard UDP WireGuard bind (`conn.NewDefaultBind()`).
- Setting `inbound.wireguard.preferTcpTransport: true` enables TCP mode: the broker dials the gateway over TCP at the **same host:port as the peer endpoint** (TCP and UDP port namespaces are independent, so no separate port is needed).
- Framing matches the gateway: each WireGuard datagram is sent as a `uint16` big-endian length prefix followed by the payload (max 65535 bytes). Inbound frames are decapsulated back into the WireGuard receive path. Empty frames are ignored.
- The gateway routes replies by the TCP connection's remote address, so the broker only needs an outbound connection — no listening socket.

## Implementation

- `pkg/wireguard_tcp.go` — a custom `conn.Bind` (`wireguardTcpBind`) plus the framing helpers, kept separate from the UDP path so the default case stays easy to reason about.
  - A single manager goroutine owns the connection lifecycle: dial → read loop → reconnect with **bounded exponential backoff** (500ms → 30s). Backoff resets on a successful connect so a single drop reconnects promptly, while a flapping gateway still backs off.
  - **Writes are serialized** under a mutex so concurrent WireGuard sends can't interleave frames; each frame is written in a single `Write`. A write failure tears down the connection so the manager reconnects.
  - Failed connections are always closed and replaced; `Close()` drains the goroutine and socket to avoid unbounded growth.
- `pkg/config.go` — adds `WireguardBase.PreferTcpTransport` (`preferTcpTransport`), default `false` (UDP).
- `pkg/wireguard.go` — `newBind()` selects UDP vs TCP based on config.
- README — documents the new option.

## Tests

`pkg/wireguard_tcp_test.go`:
- frame read/write round trip (incl. max-size payload), empty-frame handling
- oversized-frame rejection
- broker TCP bind **sends** framed packets
- broker TCP bind **receives** framed packets
- **reconnect** after a connection drop; `Close()` unblocks the receive func

`it/e2e_tcp_test.go`:
- Full end-to-end: a real WireGuard gateway device fronted by a TCP↔UDP shim (listening on the same port the gateway uses for UDP, mirroring the gateway PR's encapsulation), proving the broker establishes a tunnel and proxies HTTP entirely over the framed TCP transport.

All 40 tests pass (`go test ./...`); bind tests also pass under `-race`. `go vet` clean.

## Compatibility note

The tunnel comes up once the broker's persistent keepalive triggers the initial handshake over TCP (same mechanism as the existing UDP path). On reconnect, WireGuard's handshake/keepalive retransmission re-establishes the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)