### PR TITLE
feat(allowlist): add create-branch endpoints for GitLab, Bitbucket DC, and Azure DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Adding a `gitlab` field to the config implicitly adds these endpoints to the all
 - POST `https://gitlab.example.com/api/v4/projects/:project/hooks`
 - POST `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions`
 - POST `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions/:discussion/notes`
+- POST `https://gitlab.example.com/api/v4/projects/:project/repository/branches`
 - PUT `https://gitlab.example.com/api/v4/groups/:namespace/hooks`
 - PUT `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions/:discussion`
 - PUT `https://gitlab.example.com/api/v4/projects/:project/merge_requests/:number/discussions/:discussion/notes/:note`
@@ -246,6 +247,7 @@ Adding a `bitbucket` field to the config implicitly adds these endpoints to the 
 - GET `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/pull-requests/:number/comments/:comment`
 - GET `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/webhooks`
 - GET `https://bitbucket.example.com/rest/api/latest/projects/:project/webhooks`
+- POST `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/branches`
 - POST `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/pull-requests/:number/blocker-comments`
 - POST `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/pull-requests/:number/comments`
 - POST `https://bitbucket.example.com/rest/api/latest/projects/:project/repos/:repo/webhooks`
@@ -293,6 +295,7 @@ Adding a `azuredevops` field to the config implicitly adds these endpoints to th
 - GET `https://vsaex.dev.azure.com/:namespace/_apis/groupentitlements`
 - POST `https://dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests/:number/threads`
 - POST `https://dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests/:number/threads/:threadId/comments`
+- POST `https://dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/refs`
 - POST `https://dev.azure.com/:namespace/:project/_apis/hooks/subscriptions`
 - PUT `https://dev.azure.com/:namespace/:project/_apis/hooks/subscriptions`
 - PATCH `https://dev.azure.com/:namespace/:project/_apis/git/repositories/:repo/pullRequests/:number/threads`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -842,10 +842,10 @@ func PopulateAllowLists(config *Config) error {
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
-			// Branches
+			// Branches (GET to list; POST to create a branch)
 			AllowlistItem{
 				URL:               gitLabBaseUrl.JoinPath("/projects/:project/repository/branches").String(),
-				Methods:           ParseHttpMethods([]string{"GET"}),
+				Methods:           ParseHttpMethods([]string{"GET", "POST"}),
 				SetRequestHeaders: headers,
 			},
 			// Get branch
@@ -1013,10 +1013,11 @@ func PopulateAllowLists(config *Config) error {
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
-			// list branches (used for branch existence check with filterText)
+			// branches (GET to list / check existence with filterText; POST to
+			// create a branch and for the write-permission check)
 			AllowlistItem{
 				URL:               bitBucketBaseUrl.JoinPath("/projects/:project/repos/:repo/branches").String(),
-				Methods:           ParseHttpMethods([]string{"GET"}),
+				Methods:           ParseHttpMethods([]string{"GET", "POST"}),
 				SetRequestHeaders: headers,
 			},
 			// pull requests
@@ -1151,10 +1152,10 @@ func PopulateAllowLists(config *Config) error {
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
-			// get refs (used for branch existence check)
+			// refs (GET for branch existence check; POST to create a branch)
 			AllowlistItem{
 				URL:               azureDevOpsBaseUrl.JoinPath("/:namespace/:project/_apis/git/repositories/:repo/refs").String(),
-				Methods:           ParseHttpMethods([]string{"GET"}),
+				Methods:           ParseHttpMethods([]string{"GET", "POST"}),
 				SetRequestHeaders: headers,
 			},
 			// get pull requests


### PR DESCRIPTION
scm-drivers added a create_branch operation across all SCM drivers (semgrep/scm-drivers c408f98). Allow the outbound endpoints it hits for the providers that route through the broker:

- GitLab:            POST /projects/:project/repository/branches
- Bitbucket DC:      POST /projects/:project/repos/:repo/branches
- Azure DevOps:      POST /:namespace/:project/_apis/git/repositories/:repo/refs

Each path already permitted GET (branch existence checks), so this only adds the POST verb to the existing entry. The Bitbucket Data Center addition also unblocks the pre-existing ping_write_contents write-permission check, which POSTs to the same /branches path and was previously GET-only.

Bitbucket Cloud is intentionally excluded: its scm-drivers API host is hardcoded to https://api.bitbucket.org/2.0 (not derived from a configurable base URL), so its traffic never traverses the broker and it has no provider here.

README allowlist tables regenerated via tools/readme-url-populator.