### PR TITLE
feat(allowlist): add GET /user/memberships/orgs/:org to GitHub allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Adding a `github` field to the config implicitly adds these endpoints to the all
 - GET `https://github.example.com/api/v3/repos/:owner/:repo/pulls`
 - GET `https://github.example.com/api/v3/repos/:owner/:repo/pulls/comments/:comment_id/reactions`
 - GET `https://github.example.com/api/v3/user`
+- GET `https://github.example.com/api/v3/user/memberships/orgs/:org`
 - GET `https://github.example.com/api/v3/user/repos`
 - GET `https://github.example.com/api/v3/users/:user/installation`
 - GET `https://github.example.com/api/v3/users/:user/installation/repositories`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -480,6 +480,12 @@ func PopulateAllowLists(config *Config) error {
 				Methods:           ParseHttpMethods([]string{"GET"}),
 				SetRequestHeaders: headers,
 			},
+			// get the authenticated user's membership in an organization
+			AllowlistItem{
+				URL:               gitHubBaseUrl.JoinPath("/user/memberships/orgs/:org").String(),
+				Methods:           ParseHttpMethods([]string{"GET"}),
+				SetRequestHeaders: headers,
+			},
 			// PR info
 			AllowlistItem{
 				URL:               gitHubBaseUrl.JoinPath("/repos/:owner/:repo/pulls").String(),


### PR DESCRIPTION
semgrep/scm-drivers#47 adds a call for `GET /user/memberships/orgs/{org}` to check the authenticated token owner's own membership/role in an org. The existing `/user and /orgs/:org/*` patterns don't cover this path, so add it explicitly. Read-only GET; one entry covers both Cloud (api.github.com) and GHES (/api/v3) since it's built off the configured base URL.

Regenerated README allowlist via tools/readme-url-populator.